### PR TITLE
allow user to be specified when raising the error

### DIFF
--- a/lib/raygun.js
+++ b/lib/raygun.js
@@ -36,7 +36,7 @@ var Raygun = function () {
       .setMachineName()
       .setEnvironmentDetails()
       .setUserCustomData(customData)
-      .setUser(_user||user)
+      .setUser(user||_user)
       .setVersion(_version);
 
     var message = builder.build();


### PR DESCRIPTION
Allow the override of the user when raising the error. 

Setting an instance level user doesn't make sense when the user is set per request (end up with errors attached to the wrong user)
