### PR TITLE
handle os.cpus() returning undefined

### DIFF
--- a/lib/raygun.messageBuilder.js
+++ b/lib/raygun.messageBuilder.js
@@ -97,9 +97,9 @@ var RaygunMessageBuilder = function () {
 
   this.setUser = function (user) {
     if (user instanceof Function) {
-	message.details.user = { 'identifier': user() };
+      message.details.user = { 'identifier': user() };
     } else {
-	message.details.user = { 'identifier': user };
+      message.details.user = { 'identifier': user };
     }
     return this;
   };


### PR DESCRIPTION
It seems that on some systems os.cpus() will return undefined, added a guard so that in this case we don't return any cpu information
