### PR TITLE
Fix usage of deprecated method for request host

### DIFF
--- a/lib/raygun.messageBuilder.js
+++ b/lib/raygun.messageBuilder.js
@@ -111,7 +111,7 @@ var RaygunMessageBuilder = function (options) {
   this.setRequestDetails = function (request) {
     if (request) {
       message.details.request = {
-        hostName: request.host,
+        hostName: request.hostname,
         url: request.path,
         httpMethod: request.method,
         ipAddress: request.ip,

--- a/test/raygun.messageBuilder_test.js
+++ b/test/raygun.messageBuilder_test.js
@@ -141,7 +141,7 @@ test('custom data builder', function (t) {
 
 test('express request builder', function (t) {
   var builder = new MessageBuilder();
-  builder.setRequestDetails({ host: 'localhost' });
+  builder.setRequestDetails({ hostname: 'localhost' });
   var message = builder.build();
   
   t.ok(message.details.request.hostName);


### PR DESCRIPTION
Fix deprecation warnings in the log when using the express handler.

```js
express deprecated req.host: Use req.hostname instead node_modules/raygun/lib/raygun.messageBuilder.js:114:26
```