### PR TITLE
Add express3 support back

### DIFF
--- a/lib/raygun.messageBuilder.js
+++ b/lib/raygun.messageBuilder.js
@@ -111,7 +111,7 @@ var RaygunMessageBuilder = function (options) {
   this.setRequestDetails = function (request) {
     if (request) {
       message.details.request = {
-        hostName: request.hostname,
+        hostName: request.hostname || request.host,
         url: request.path,
         httpMethod: request.method,
         ipAddress: request.ip,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun.io plugin for Node",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "MindscapeHQ",

--- a/test/raygun.messageBuilder_test.js
+++ b/test/raygun.messageBuilder_test.js
@@ -139,11 +139,20 @@ test('custom data builder', function (t) {
   t.end();
 });
 
-test('express request builder', function (t) {
+test('express4 request builder', function (t) {
   var builder = new MessageBuilder();
   builder.setRequestDetails({ hostname: 'localhost' });
   var message = builder.build();
   
+  t.ok(message.details.request.hostName);
+  t.end();
+});
+
+test('express3 request builder', function (t) {
+  var builder = new MessageBuilder();
+  builder.setRequestDetails({ host: 'localhost' });
+  var message = builder.build();
+
   t.ok(message.details.request.hostName);
   t.end();
 });


### PR DESCRIPTION
Need to keep checking request.host so raygun4node still works under Express3

Also updates the package version to 0.6.1