### PR TITLE
Handle network errors when uploading to api.raygun.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ The [Express documentation](http://expressjs.com/guide/error-handling.html) says
 
 ## Documentation
 
+### Callbacks
+
+The callback should be a node-style callback: `function(err, response) { /*...*/ }`.
+*Note*: If the callback only takes one parameter (`function(response){ /*...*/ }`)
+it will only be called when the transmission is successful. This is included for
+backwards compatibility; the Node-style callback should be preferred.
+
 ### Sending custom data
 
 You can pass custom data in on the Send() function, as the second parameter. For instance (based off the call in test/raygun_test.js):

--- a/lib/raygun.transport.js
+++ b/lib/raygun.transport.js
@@ -24,11 +24,21 @@ var send = function (options) {
     }
   };
   var request = http.request(httpOptions, function (response) {
+    // If the callback has two parameters, it should expect an `error` value.
     if (options.callback) {
-      options.callback(response);
+      if (options.callback.length > 1) {
+        options.callback(null, response);
+      } else {
+        options.callback(response);
+      }
     }
   });
-
+  request.on("error", function(err) {
+    // If the callback has two parameters, it should expect an `error` value.
+    if (options.callback && options.callback.length > 1) {
+      options.callback(err);
+    }
+  });
   request.write(data);
   request.end();
 };


### PR DESCRIPTION
This avoids unhandled exceptions due to failed DNS lookups or certificate issues. I also took the liberty of extending the callback to allow receiving an error, if the callback takes more than one parameter.