### PR TITLE
allow passing in a string as an error

### DIFF
--- a/lib/raygun.messageBuilder.js
+++ b/lib/raygun.messageBuilder.js
@@ -49,6 +49,10 @@ var RaygunMessageBuilder = function (options) {
   };
 
   this.setErrorDetails = function (error) {
+    if (typeof error === "string") {
+      error = new Error(error);
+    }
+      
     var stack = [];
     var trace = stackTrace.parse(error);
     trace.forEach(function (callSite) {

--- a/test/raygun.messageBuilder_test.js
+++ b/test/raygun.messageBuilder_test.js
@@ -103,6 +103,16 @@ test('error builder tests', function (t) {
     tt.equals(message.details.error.className, 'Error');
     tt.end();
   });
+  
+  t.test('error from string', function(tt) {
+    var errorMessage = 'WarpCoreAlignment';
+    var builder = new MessageBuilder();
+    builder.setErrorDetails(errorMessage);
+    var message = builder.build();
+    tt.ok(message.details.error.message);
+    tt.equals(message.details.error.message, errorMessage);
+    tt.end();
+  });
 });
 
 test('environment builder', function (t) {


### PR DESCRIPTION
it happened in our team a few times that developers would pass a string instead of an error instance to Raygun and then the log was full of `NoMessage` errors. This is an easy fix for this. I'm sure others have run into this as well.