### PR TITLE
Handle request errors and log out to console

### DIFF
--- a/lib/raygun.transport.js
+++ b/lib/raygun.transport.js
@@ -33,6 +33,10 @@ var send = function (options) {
     var httpLib = options.useSSL ? https : http;
     var request = httpLib.request(httpOptions, cb);
 
+    request.on("error", function (e) {
+      console.log("Raygun: error " + e.message + " occurred while attempting to send error with message: " + options.message);
+    });
+    
     request.write(data);
     request.end();
   } catch (e) {


### PR DESCRIPTION
Request errors should be caught and logged out, otherwise the node process will crash if it can't connect to Raygun. 