### PR TITLE
Object to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+- 0.8.4 - Add some smarts around passing an object in to the exception parameter
 - 0.8.3 - Turn strings into errors if passed through. Log out request errors.
 - 0.8.2 - Add setTags method
 - 0.8.1 - Add custom error grouping key

--- a/lib/raygun.messageBuilder.js
+++ b/lib/raygun.messageBuilder.js
@@ -10,6 +10,7 @@
 
 var stackTrace = require('stack-trace');
 var os = require('os');
+var humanString = require('object-to-human-string');
 var packageDetails = require('../package.json');
 
 function filterKeys(obj, filters) {
@@ -29,7 +30,7 @@ function filterKeys(obj, filters) {
 var RaygunMessageBuilder = function (options) {
   options = options || {};
   var _filters;
-  
+
   if (Array.isArray(options.filters)) {
     _filters = options.filters;
   }
@@ -49,10 +50,20 @@ var RaygunMessageBuilder = function (options) {
   };
 
   this.setErrorDetails = function (error) {
-    if (typeof error === "string") {
-      error = new Error(error);
+    var errorType = Object.prototype.toString.call(error);
+
+    if (errorType === '[object Object]') {
+      error = humanString(error);
     }
-      
+
+    if (typeof error === "string") {
+      message.details.error = {
+        message: error
+      };
+
+      return this;
+    }
+
     var stack = [];
     var trace = stackTrace.parse(error);
     trace.forEach(function (callSite) {
@@ -146,19 +157,19 @@ var RaygunMessageBuilder = function (options) {
     }
     return data;
   };
-  
+
   this.setUser = function (user) {
     var userData = user;
     if (user instanceof Function) {
       userData = user();
     }
-    
+
     if (userData instanceof Object) {
         message.details.user = extractUserProperties(userData);
-    } else {     
+    } else {
         message.details.user = { 'identifier': userData };
     }
-    
+
     return this;
   };
 

--- a/lib/raygun.messageBuilder.js
+++ b/lib/raygun.messageBuilder.js
@@ -54,6 +54,7 @@ var RaygunMessageBuilder = function (options) {
 
     if (errorType === '[object Object]') {
       error = humanString(error);
+      message.details.groupingKey = error.replace(/\W+/g, "").substring(0, 64);
     }
 
     if (typeof error === "string") {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "tap": "^0.4.13"
   },
   "dependencies": {
-    "install": "^0.4.1",
-    "npm": "^3.5.2",
     "object-to-human-string": "0.0.3",
     "stack-trace": "0.0.6"
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "tap": "^0.4.13"
   },
   "dependencies": {
+    "install": "^0.4.1",
+    "npm": "^3.5.2",
+    "object-to-human-string": "0.0.3",
     "stack-trace": "0.0.6"
   },
   "keywords": []

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun.io plugin for Node",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "MindscapeHQ",


### PR DESCRIPTION
Fixes a weird as edge case where if you pass an object through on the exception parameter, it kinda gets converted to a string. This is fine in Raygun, but it breaks once it reaches the notification stuff.

Not an overly common problem, I'm sure, but has come up through support and it seems like a worthwhile fix.