### PR TITLE
fixed useSSL option, and support for using proxies.

### DIFF
--- a/lib/raygun.js
+++ b/lib/raygun.js
@@ -22,7 +22,7 @@ var Raygun = function () {
         _filters = options.filters;
         _host = options.host;
         _port = options.port;
-        _useSSL = options.useSSL || true;
+        _useSSL = options.useSSL !== false;
         _onBeforeSend = options.onBeforeSend;
         _offlineStorage = options.offlineStorage || new OfflineStorage();
         _offlineStorageOptions = options.offlineStorageOptions;

--- a/lib/raygun.transport.js
+++ b/lib/raygun.transport.js
@@ -11,18 +11,31 @@
 var http = require('http');
 var https = require('https');
 
+var API_HOST = 'api.raygun.io';
+
+var getFullPath = function(options) {
+  var useSSL   = options.useSSL,
+      port     = useSSL ? 443 : 80,
+      protocol = useSSL ? 'https' : 'http';
+
+  return protocol + '://' + API_HOST + ':' + port + '/entries';
+};
+
 var send = function (options) {
   try {
     var data = new Buffer(JSON.stringify(options.message), 'utf8');
+    var fullPath = getFullPath(options);
+
     var httpOptions = {
-      host: options.host || 'api.raygun.io',
+      host: options.host || API_HOST,
       port: options.port || 443,
-      path: '/entries',
+      path: fullPath,
       method: 'POST',
       headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': data.length,
-          'X-ApiKey': options.apiKey
+        'Host': API_HOST,
+        'Content-Type': 'application/json',
+        'Content-Length': data.length,
+        'X-ApiKey': options.apiKey
       }
     };
     var cb = function (response) {
@@ -36,7 +49,7 @@ var send = function (options) {
     request.on("error", function (e) {
       console.log("Raygun: error " + e.message + " occurred while attempting to send error with message: " + options.message);
     });
-    
+
     request.write(data);
     request.end();
   } catch (e) {


### PR DESCRIPTION
Fixed useSSL option passed in the ```init() options```, which was always evaluating to truthy. Also added proper support for the use of http proxies, by adding the host header on the request set to 'api.raygun.io', and setting the full path to the /entries url, which is all required for being able to send the request through a proxy (http://stackoverflow.com/questions/3862813/how-can-i-use-an-http-proxy-with-node-js-http-client).

An example setup would look like:

```
var raygun = require('raygun');

var raygunClient = new raygun.Client().init({ 
   apiKey: 'xxxx',
   host: 'myproxy.somedomain.co.uk',
   useSSL : false,
   port : 3128
});
```