### PR TITLE
treat custom errors as Error's

### DIFF
--- a/lib/raygun.messageBuilder.js
+++ b/lib/raygun.messageBuilder.js
@@ -50,8 +50,6 @@ var RaygunMessageBuilder = function (options) {
   };
 
   this.setErrorDetails = function (error) {
-    var errorType = Object.prototype.toString.call(error);
-
     if (!(error instanceof Error) && options.useHumanStringForObject) {
       error = humanString(error);
       message.details.groupingKey = error.replace(/\W+/g, "").substring(0, 64);

--- a/lib/raygun.messageBuilder.js
+++ b/lib/raygun.messageBuilder.js
@@ -52,7 +52,7 @@ var RaygunMessageBuilder = function (options) {
   this.setErrorDetails = function (error) {
     var errorType = Object.prototype.toString.call(error);
 
-    if (!(errorType instanceof Error) && options.useHumanStringForObject) {
+    if (!(error instanceof Error) && options.useHumanStringForObject) {
       error = humanString(error);
       message.details.groupingKey = error.replace(/\W+/g, "").substring(0, 64);
     }

--- a/lib/raygun.messageBuilder.js
+++ b/lib/raygun.messageBuilder.js
@@ -52,7 +52,7 @@ var RaygunMessageBuilder = function (options) {
   this.setErrorDetails = function (error) {
     var errorType = Object.prototype.toString.call(error);
 
-    if (errorType === '[object Object]' && options.useHumanStringForObject) {
+    if (!(errorType instanceof Error) && options.useHumanStringForObject) {
       error = humanString(error);
       message.details.groupingKey = error.replace(/\W+/g, "").substring(0, 64);
     }


### PR DESCRIPTION
When extending the Error object (many libs do this) raygun treats them as plain Object.
By replacing this check with an instanceof, error objects will be treated as such.