### PR TITLE
Inner error support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.0
+- Add support for inner errors. Option `innerErrorFieldName` to specify a field or a function on the error object to use for retrieval of an inner error. Defaults to `cause` which is used in [VError](https://github.com/joyent/node-verror)
+
 ## 0.9.1
 
 - Add an option to report column number for each frame of the stack trace

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Release 0.3 previously had a setUser function that accepted a string or function
 
 Call setVersion(*string*) on a RaygunClient to set the version of the calling application. This is expected to be of the format x.x.x.x, where x is a positive integer. The version will be visible in the dashboard.
 
+### Inner Errors
+
+Starting from 0.10.0 support for inner errors was added. Provide option `innerErrorFieldName` to specify a field or a function on the error object to use for retrieval of an inner error. Inner errors will be retrieved recursively until there is no more errors. Option `innerErrorFieldName` defaults to `cause` which is used in [VError](https://github.com/joyent/node-verror), therefore `VError` is supported out of the box.
+
 ### Changing the API endpoint
 
 You can change the endpoint that error messages are sent to by specifying the `host`, `port`, and `useSSL` properties in the `raygunClient.init()` options hash. By default, `host` is `api.raygun.io`, `port` is `443`, and `useSSL` is `true`.

--- a/lib/raygun.js
+++ b/lib/raygun.js
@@ -15,7 +15,7 @@ var MessageBuilder = require('./raygun.messageBuilder');
 var OfflineStorage = require('./raygun.offline');
 
 var Raygun = function () {
-    var _apiKey, _filters, raygun = this, _user, _version, _host, _port, _useSSL, _onBeforeSend, _offlineStorage, _isOffline, _offlineStorageOptions, _groupingKey, _tags, _useHumanStringForObject, _reportColumnNumbers;
+    var _apiKey, _filters, raygun = this, _user, _version, _host, _port, _useSSL, _onBeforeSend, _offlineStorage, _isOffline, _offlineStorageOptions, _groupingKey, _tags, _useHumanStringForObject, _reportColumnNumbers, _innerErrorFieldName;
 
     raygun.init = function (options) {
         _apiKey = options.apiKey;
@@ -31,6 +31,7 @@ var Raygun = function () {
         _tags = options.tags;
         _useHumanStringForObject = options.useHumanStringForObject === undefined ? true : options.useHumanStringForObject;
         _reportColumnNumbers = options.reportColumnNumbers;
+        _innerErrorFieldName = options.innerErrorFieldName || 'cause'; // VError function to retrieve inner error;
 
         if (_isOffline) {
             _offlineStorage.init(_offlineStorageOptions);
@@ -94,7 +95,7 @@ var Raygun = function () {
             mergedTags = mergedTags.concat(tags);
         }
 
-        var builder = new MessageBuilder({filters: _filters, useHumanStringForObject: _useHumanStringForObject, reportColumnNumbers: _reportColumnNumbers})
+        var builder = new MessageBuilder({filters: _filters, useHumanStringForObject: _useHumanStringForObject, reportColumnNumbers: _reportColumnNumbers, innerErrorFieldName: _innerErrorFieldName})
             .setErrorDetails(exception)
             .setRequestDetails(request)
             .setMachineName()

--- a/lib/raygun.messageBuilder.js
+++ b/lib/raygun.messageBuilder.js
@@ -27,6 +27,46 @@ function filterKeys(obj, filters) {
   return obj;
 }
 
+function getStackTrace(error, options) {
+  var stack = [];
+  var trace = stackTrace.parse(error);
+
+  trace.forEach(function (callSite) {
+    var frame = {
+      lineNumber: callSite.getLineNumber(),
+      className: callSite.getTypeName() || 'unknown',
+      fileName: callSite.getFileName(),
+      methodName: callSite.getFunctionName() || '[anonymous]'
+    };
+
+    if (!!options.reportColumnNumbers && typeof (callSite.getColumnNumber) === 'function') {
+      frame.columnNumber = callSite.getColumnNumber();
+    }
+
+    stack.push(frame);
+  });
+
+  return stack;
+}
+
+function buildError(error, options) {
+  var builtError = {
+    stackTrace: getStackTrace(error, options),
+    message: error.message || "NoMessage",
+    className: error.name
+  }; 
+
+  var innerError = error[options.innerErrorFieldName];
+  
+  innerError = typeof innerError === 'function' ? innerError() : innerError;
+
+  if(innerError instanceof Error) {
+    builtError.innerError = buildError(innerError, options);
+  }
+    
+  return builtError;
+}
+
 var RaygunMessageBuilder = function (options) {
   options = options || {};
   var _filters;
@@ -63,28 +103,7 @@ var RaygunMessageBuilder = function (options) {
       return this;
     }
 
-    var stack = [];
-    var trace = stackTrace.parse(error);
-    trace.forEach(function (callSite) {
-      var frame = {
-        lineNumber: callSite.getLineNumber(),
-        className: callSite.getTypeName() || 'unknown',
-        fileName: callSite.getFileName(),
-        methodName: callSite.getFunctionName() || '[anonymous]'
-      };
-
-      if (!!options.reportColumnNumbers && typeof (callSite.getColumnNumber) === 'function') {
-        frame.columnNumber = callSite.getColumnNumber();
-      }
-
-      stack.push(frame);
-    });
-
-    message.details.error = {
-      stackTrace: stack,
-      message: error.message || "NoMessage",
-      className: error.name
-    };
+    message.details.error = buildError(error, options);
 
     return this;
   };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun.io plugin for Node",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "MindscapeHQ",

--- a/test/raygun_send_test.js
+++ b/test/raygun_send_test.js
@@ -37,6 +37,29 @@ test('send complex', {}, function (t) {
     });
 });
 
+test('send with inner error', {}, function (t) {
+    t.plan(1);
+
+    if (semver.satisfies(process.version, '=0.10')) {
+      t.pass('Ignored on node 0.10');
+      t.end();
+      return;
+    }
+
+    var error = new Error('Outer');
+    var innerError = new Error('Inner');
+    
+    error.cause = function () {
+        return innerError;
+    };
+
+    var client = new Raygun.Client().init({apiKey: process.env['RAYGUN_APIKEY']});
+    client.send(error, {}, function (response) {
+        t.equals(response.statusCode, 202);
+        t.end();
+    });
+});
+
 test('send with OnBeforeSend', {}, function (t) {
     t.plan(1);
 


### PR DESCRIPTION
![](https://media.giphy.com/media/11C7Nu3SZAUW0U/giphy.gif)

# In this PR:
- inner errors are included in message sent to raygun API
- new option `innerErrorFieldName`
- out of the box support for [VError](https://github.com/joyent/node-verror)
- no breaking changes

closes #64 