### PR TITLE
Replace deprecated Buffer constructor with Buffer.from

### DIFF
--- a/lib/raygun.transport.js
+++ b/lib/raygun.transport.js
@@ -23,7 +23,7 @@ var getFullPath = function(options) {
 
 var send = function (options) {
   try {
-    var data = new Buffer(JSON.stringify(options.message), 'utf8');
+    var data = Buffer.from(JSON.stringify(options.message));
     var fullPath = getFullPath(options);
 
     var httpOptions = {


### PR DESCRIPTION
`new Buffer` has been deprecated and now emits a message. The particular
form of it we were using was not a vulnerability as far as I am aware,
due to passing a string value rather than a manual size, but it's still
recommended to update to `Buffer.from`.

https://nodejs.org/gl/docs/guides/buffer-constructor-deprecation/