### PR TITLE
Notify apm of exceptions

### DIFF
--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -34,8 +34,10 @@ import { v4 as uuidv4 } from "uuid";
 
 const debug = require("debug")("raygun");
 
-
-let apmBridge: undefined | null | {notify(e: string | Error, s: string): void} = undefined;
+let apmBridge:
+  | undefined
+  | null
+  | { notify(e: string | Error, s: string): void } = undefined;
 
 try {
   if (module.parent) {
@@ -222,12 +224,6 @@ class Raygun {
     request?: Request,
     tags?: Tag[]
   ): Message {
-    const correlationId = uuidv4();
-
-    if (apmBridge) {
-      apmBridge.notify(exception, correlationId);
-    }
-
     let mergedTags: Tag[] = [];
 
     if (this._tags) {
@@ -269,7 +265,13 @@ class Raygun {
           : message;
     }
 
-    message.details.correlationId = correlationId;
+    if (apmBridge) {
+      const correlationId = uuidv4();
+
+      apmBridge.notify(exception, correlationId);
+
+      message.details.correlationId = correlationId;
+    }
 
     if (this._isOffline) {
       this.offlineStorage().save(JSON.stringify(message), callback || emptyCallback);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -50,6 +50,7 @@ export type MessageDetails = {
   userCustomData: CustomData;
   machineName: string;
   environment: Environment;
+  correlationId: string | null;
 };
 
 export type Environment = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -225,6 +225,12 @@
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-8Ly3zIPTnT0/8RCU6Kg/G3uTICf9sRwYOpUzSIM3503tLIKcnJPRuinHhXngJUy2MntrEf6dlpOHXJju90Qh5w==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -1660,6 +1666,12 @@
             "which": "^1.2.9"
           }
         },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -2105,6 +2117,14 @@
         "uuid": "^3.3.2",
         "yargs": "^13.2.2",
         "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "oauth-sign": {
@@ -2531,6 +2551,12 @@
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
       }
@@ -4280,10 +4306,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/stack-trace": "0.0.29",
     "express": "^4.17.1",
     "http-terminator": "^2.0.3",
+    "@types/uuid": "^7.0.2",
     "jshint": "^2.5.6",
     "nock": "~9",
     "prettier": "^2.0.4",
@@ -57,7 +58,8 @@
   "dependencies": {
     "debug": "^4.1.1",
     "object-to-human-string": "0.0.3",
-    "stack-trace": "0.0.6"
+    "stack-trace": "0.0.6",
+    "uuid": "^7.0.3"
   },
   "keywords": []
 }


### PR DESCRIPTION
This branch adds integration with `raygun-apm` that allows for linked exceptions in the Raygun app.

We now generate a UUIDv4 to serve as a correlation id, as pass that both to the crash reporting endpoint and to the apm module. This allows the generated trace to reference the linked exception correctly.