### PR TITLE
Support batched error reporting

### DIFF
--- a/lib/raygun.batch.ts
+++ b/lib/raygun.batch.ts
@@ -91,7 +91,7 @@ export class RaygunBatchTransport {
     const payload = `[${batch.join(",")}]`;
     const runAllCallbacks = <E, R>(err: E, response: R) => {
       const [seconds, nanoseconds] = process.hrtime(startTime);
-      const durationInMs = Math.round(seconds / 1000 + nanoseconds / 1e6);
+      const durationInMs = Math.round(seconds * 1000 + nanoseconds / 1e6);
       if (err) {
         debug(
           `batch transport - error sending batch (id=${batchId}, duration=${durationInMs}ms): ${err}`

--- a/lib/raygun.batch.ts
+++ b/lib/raygun.batch.ts
@@ -21,8 +21,8 @@ export class RaygunBatchTransport {
     this.httpOptions = options.httpOptions;
   }
 
-  sendLater(messageAndCallback: MessageAndCallback) {
-    this.messageQueue.push(messageAndCallback);
+  send(message: string, callback: Function) {
+    this.messageQueue.push({serializedMessage: message, callback});
   }
 
   startProcessing() {

--- a/lib/raygun.batch.ts
+++ b/lib/raygun.batch.ts
@@ -1,10 +1,12 @@
 import { Message, HTTPOptions } from "./types";
-import { send } from './raygun.transport';
+import { send } from "./raygun.transport";
+
+const debug = require("debug")("raygun");
 
 export type MessageAndCallback = {
   serializedMessage: string;
   callback: Function;
-}
+};
 
 const MAX_MESSAGES_IN_BATCH = 100;
 const MAX_BATCH_SIZE_BYTES = 1638400;
@@ -15,22 +17,27 @@ export class RaygunBatchTransport {
   private intervalId: any | null = null;
   private httpOptions: HTTPOptions;
   private interval: number;
+  private batchId: number = 0;
 
-  constructor(options: {interval: number, httpOptions: HTTPOptions}) {
+  constructor(options: { interval: number; httpOptions: HTTPOptions }) {
     this.interval = options.interval;
     this.httpOptions = options.httpOptions;
   }
 
   send(message: string, callback: Function) {
-    this.messageQueue.push({serializedMessage: message, callback});
+    this.messageQueue.push({ serializedMessage: message, callback });
   }
 
   startProcessing() {
+    debug(
+      `batch transport - starting message processor (frequency=${this.interval})`
+    );
     this.intervalId = setInterval(this.process.bind(this), this.interval);
   }
 
   stopProcessing() {
     if (this.intervalId) {
+      debug("batch transport - stopping");
       clearInterval(this.intervalId);
 
       this.intervalId = null;
@@ -42,14 +49,21 @@ export class RaygunBatchTransport {
     const callbacks: Function[] = [];
     let batchSizeBytes = 0;
 
-    for(let i = 0; i < MAX_MESSAGES_IN_BATCH; i++) {
+    debug(
+      `batch transport - processing (${this.messageQueue.length} message(s) in queue)`
+    );
+
+    for (let i = 0; i < MAX_MESSAGES_IN_BATCH; i++) {
       if (this.messageQueue.length === 0) {
         break;
       }
 
-      const {serializedMessage, callback} = this.messageQueue[0];
+      const { serializedMessage, callback } = this.messageQueue[0];
 
-      if (batchSizeBytes + serializedMessage.length > MAX_BATCH_INNER_SIZE_BYTES) {
+      if (
+        batchSizeBytes + serializedMessage.length >
+        MAX_BATCH_INNER_SIZE_BYTES
+      ) {
         break;
       }
 
@@ -67,24 +81,45 @@ export class RaygunBatchTransport {
       this.messageQueue.shift();
     }
 
-    if (batch.length === 0) { return; }
+    if (batch.length === 0) {
+      return;
+    }
 
-    const payload = `[${batch.join(',')}]`;
+    const batchId = this.batchId;
+    this.batchId++;
+
+    const payload = `[${batch.join(",")}]`;
     const runAllCallbacks = <E, R>(err: E, response: R) => {
-      for (let callback of callbacks) {
+      const [seconds, nanoseconds] = process.hrtime(startTime);
+      const durationInMs = Math.round(seconds / 1000 + nanoseconds / 1e6);
+      if (err) {
+        debug(
+          `batch transport - error sending batch (id=${batchId}, duration=${durationInMs}ms): ${err}`
+        );
+      } else {
+        debug(
+          `batch transport - successfully sent batch (id=${batchId}, duration=${durationInMs}ms)`
+        );
+      }
+      for (const callback of callbacks) {
         if (callback.length > 1) {
           callback(err, response);
         } else {
           callback(response);
         }
       }
-    }
+    };
 
+    debug(
+      `batch transport - sending batch (id=${batchId}) (${batch.length} messages, ${payload.length} bytes)`
+    );
+
+    const startTime = process.hrtime();
     send({
       message: payload,
       callback: runAllCallbacks,
       http: this.httpOptions,
-      batch: true
+      batch: true,
     });
   }
 }

--- a/lib/raygun.batch.ts
+++ b/lib/raygun.batch.ts
@@ -1,0 +1,90 @@
+import { Message, HTTPOptions } from "./types";
+import { send } from './raygun.transport';
+
+export type MessageAndCallback = {
+  serializedMessage: string;
+  callback: Function;
+}
+
+const MAX_MESSAGES_IN_BATCH = 100;
+const MAX_BATCH_SIZE_BYTES = 1638400;
+const MAX_BATCH_INNER_SIZE_BYTES = MAX_BATCH_SIZE_BYTES - 2; // for the starting and ending byte
+
+export class RaygunBatchTransport {
+  private messageQueue: MessageAndCallback[] = [];
+  private intervalId: any | null = null;
+  private httpOptions: HTTPOptions;
+  private interval: number;
+
+  constructor(options: {interval: number, httpOptions: HTTPOptions}) {
+    this.interval = options.interval;
+    this.httpOptions = options.httpOptions;
+  }
+
+  sendLater(messageAndCallback: MessageAndCallback) {
+    this.messageQueue.push(messageAndCallback);
+  }
+
+  startProcessing() {
+    this.intervalId = setInterval(this.process.bind(this), this.interval);
+  }
+
+  stopProcessing() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+
+      this.intervalId = null;
+    }
+  }
+
+  private process() {
+    const batch: string[] = [];
+    const callbacks: Function[] = [];
+    let batchSizeBytes = 0;
+
+    for(let i = 0; i < MAX_MESSAGES_IN_BATCH; i++) {
+      if (this.messageQueue.length === 0) {
+        break;
+      }
+
+      const {serializedMessage, callback} = this.messageQueue[0];
+
+      if (batchSizeBytes + serializedMessage.length > MAX_BATCH_INNER_SIZE_BYTES) {
+        break;
+      }
+
+      batch.push(serializedMessage);
+      if (callback) {
+        callbacks.push(callback);
+      }
+
+      if (i === 0) {
+        batchSizeBytes += serializedMessage.length;
+      } else {
+        batchSizeBytes += serializedMessage.length + 1; // to account for the commas between items
+      }
+
+      this.messageQueue.shift();
+    }
+
+    if (batch.length === 0) { return; }
+
+    const payload = `[${batch.join(',')}]`;
+    const runAllCallbacks = <E, R>(err: E, response: R) => {
+      for (let callback of callbacks) {
+        if (callback.length > 1) {
+          callback(err, response);
+        } else {
+          callback(response);
+        }
+      }
+    }
+
+    send({
+      message: payload,
+      callback: runAllCallbacks,
+      http: this.httpOptions,
+      batch: true
+    });
+  }
+}

--- a/lib/raygun.offline.ts
+++ b/lib/raygun.offline.ts
@@ -13,6 +13,8 @@ import path from "path";
 import * as raygunTransport from "./raygun.transport";
 import { Transport, OfflineStorageOptions } from "./types";
 
+const debug = require("debug")("raygun");
+
 export class OfflineStorage {
   cachePath: string = "";
   cacheLimit: number = 100;
@@ -34,7 +36,10 @@ export class OfflineStorage {
     });
   }
 
-  init(offlineStorageOptions: OfflineStorageOptions | undefined, transport: Transport) {
+  init(
+    offlineStorageOptions: OfflineStorageOptions | undefined,
+    transport: Transport
+  ) {
     if (!offlineStorageOptions || !offlineStorageOptions.cachePath) {
       throw new Error("Cache Path must be set before Raygun can cache offline");
     }
@@ -42,6 +47,8 @@ export class OfflineStorage {
     this.cachePath = offlineStorageOptions.cachePath;
     this.cacheLimit = offlineStorageOptions.cacheLimit || 100;
     this.transport = transport;
+
+    debug(`offline storage - initialized (cachePath=${this.cachePath}, cacheLimit=${this.cacheLimit}`);
 
     if (!fs.existsSync(this.cachePath)) {
       fs.mkdirSync(this.cachePath);
@@ -71,10 +78,9 @@ export class OfflineStorage {
         return callback(null);
       }
 
-      fs.writeFile(filename, transportItem, "utf8", function (
-        err
-      ) {
+      fs.writeFile(filename, transportItem, "utf8", function (err) {
         if (!err) {
+          debug(`offline storage - wrote message to ${filename}`);
           return callback(null);
         }
 
@@ -104,6 +110,10 @@ export class OfflineStorage {
         console.log("[Raygun] Error reading cache folder");
         console.log(err);
         return callback(err);
+      }
+
+      if (items.length > 0) {
+        debug("offline storage - transporting ${items.length} message(s) from cache");
       }
 
       for (let i = 0; i < items.length; i++) {

--- a/lib/raygun.offline.ts
+++ b/lib/raygun.offline.ts
@@ -48,7 +48,9 @@ export class OfflineStorage {
     this.cacheLimit = offlineStorageOptions.cacheLimit || 100;
     this.transport = transport;
 
-    debug(`offline storage - initialized (cachePath=${this.cachePath}, cacheLimit=${this.cacheLimit}`);
+    debug(
+      `offline storage - initialized (cachePath=${this.cachePath}, cacheLimit=${this.cacheLimit}`
+    );
 
     if (!fs.existsSync(this.cachePath)) {
       fs.mkdirSync(this.cachePath);
@@ -113,7 +115,9 @@ export class OfflineStorage {
       }
 
       if (items.length > 0) {
-        debug("offline storage - transporting ${items.length} message(s) from cache");
+        debug(
+          "offline storage - transporting ${items.length} message(s) from cache"
+        );
       }
 
       for (let i = 0; i < items.length; i++) {

--- a/lib/raygun.transport.ts
+++ b/lib/raygun.transport.ts
@@ -12,7 +12,7 @@ import http from "http";
 import https from "https";
 
 import { IncomingMessage } from "http";
-import { SendOptions } from "./types";
+import { isCallbackWithError, SendOptions } from "./types";
 
 const debug = require("debug")("raygun");
 
@@ -40,7 +40,7 @@ export function send(options: SendOptions) {
 
     const cb = function (response: IncomingMessage) {
       if (options.callback) {
-        if (options.callback.length > 1) {
+        if (isCallbackWithError(options.callback)) {
           options.callback(null, response);
         } else {
           options.callback(response);
@@ -57,8 +57,8 @@ export function send(options: SendOptions) {
       );
 
       // If the callback has two parameters, it should expect an `error` value.
-      if (options.callback && options.callback.length > 1) {
-        options.callback(e);
+      if (options.callback && isCallbackWithError(options.callback)) {
+        options.callback(e, null);
       }
     });
 

--- a/lib/raygun.transport.ts
+++ b/lib/raygun.transport.ts
@@ -14,10 +14,11 @@ import https from "https";
 import { IncomingMessage } from "http";
 import { SendOptions } from "./types";
 
+const debug = require("debug")("raygun");
+
 const API_HOST = "api.raygun.io";
 const DEFAULT_ENDPOINT = "/entries";
 const BATCH_ENDPOINT = "/entries/bulk";
-
 
 export function send(options: SendOptions) {
   try {

--- a/lib/raygun.transport.ts
+++ b/lib/raygun.transport.ts
@@ -12,7 +12,7 @@ import http from "http";
 import https from "https";
 
 import { IncomingMessage } from "http";
-import { isCallbackWithError, SendOptions } from "./types";
+import { isCallbackWithError, callVariadicCallback, SendOptions } from "./types";
 
 const debug = require("debug")("raygun");
 
@@ -40,11 +40,7 @@ export function send(options: SendOptions) {
 
     const cb = function (response: IncomingMessage) {
       if (options.callback) {
-        if (isCallbackWithError(options.callback)) {
-          options.callback(null, response);
-        } else {
-          options.callback(response);
-        }
+        return callVariadicCallback(options.callback, null, response);
       }
     };
 

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -59,8 +59,6 @@ class Raygun {
     this._port = options.port;
     this._useSSL = options.useSSL !== false;
     this._onBeforeSend = options.onBeforeSend;
-    this._offlineStorage = options.offlineStorage || new OfflineStorage();
-    this._offlineStorageOptions = options.offlineStorageOptions;
     this._isOffline = options.isOffline;
     this._groupingKey = options.groupingKey;
     this._tags = options.tags;
@@ -90,8 +88,11 @@ class Raygun {
 
     this.expressHandler = this.expressHandler.bind(this);
 
+    this._offlineStorage = options.offlineStorage || new OfflineStorage(this.transport());
+    this._offlineStorageOptions = options.offlineStorageOptions;
+
     if (this._isOffline) {
-      this._offlineStorage.init(this._offlineStorageOptions, this.transport());
+      this._offlineStorage.init(this._offlineStorageOptions);
     }
 
     return this;
@@ -128,7 +129,7 @@ class Raygun {
   }
 
   offline() {
-    this.offlineStorage().init(this._offlineStorageOptions, this.transport());
+    this.offlineStorage().init(this._offlineStorageOptions);
     this._isOffline = true;
   }
 
@@ -141,7 +142,7 @@ class Raygun {
     this._tags = tags;
   }
 
-  transport() {
+  transport(): Transport {
     if (this._batch && this._batchTransport) {
       return this._batchTransport;
     }
@@ -283,7 +284,7 @@ class Raygun {
       return storage;
     }
 
-    storage = this._offlineStorage = new OfflineStorage();
+    storage = this._offlineStorage = new OfflineStorage(this.transport());
 
     return storage;
   }

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -163,7 +163,7 @@ class Raygun {
 
         function wrappedCallback<R>(error: Error | null, response: R) {
           const [seconds, nanoseconds] = process.hrtime(startTime);
-          const durationInMs = Math.round(seconds / 1000 + nanoseconds / 1e6);
+          const durationInMs = Math.round(seconds * 1000 + nanoseconds / 1e6);
           if (error) {
             debug(
               `error sending message (duration=${durationInMs}ms): ${error}`

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -85,7 +85,7 @@ class Raygun {
           port: this._port,
           useSSL: !!this._useSSL,
           apiKey: this._apiKey,
-        },
+        }
       });
       this._batchTransport.startProcessing();
     }

--- a/lib/timer.ts
+++ b/lib/timer.ts
@@ -1,0 +1,9 @@
+export function startTimer(): () => number {
+  const startTime = process.hrtime();
+
+  return function stopTimer() {
+    const [seconds, nanoseconds] = process.hrtime(startTime);
+    return Math.round(seconds * 1000 + nanoseconds / 1e6); // in milliseconds
+  }
+}
+

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -63,13 +63,19 @@ export type Environment = {
 export type Tag = string;
 
 export type SendOptions = {
-  message: Message;
+  message: string;
+  callback: Function;
+  http: HTTPOptions;
+  batch: boolean;
+}
+
+export type HTTPOptions = {
   useSSL: boolean;
   host: string | undefined;
   port: number | undefined;
   apiKey: string;
-  callback: Function;
 };
+
 
 export type CustomData = any;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+import type { IncomingMessage } from "http";
+
 export type IndexableError = Error & {
   [key: string]: any;
 };
@@ -64,7 +66,7 @@ export type Tag = string;
 
 export type SendOptions = {
   message: string;
-  callback: Function;
+  callback: Callback<IncomingMessage>;
   http: HTTPOptions;
   batch: boolean;
 };
@@ -135,13 +137,14 @@ export type Hook<T> = (
   tags?: Tag[]
 ) => T;
 
-// TODO - it would be nice to be more specific than Function, maybe a union type of the different callback types
 export type IOfflineStorage = {
   init(options: OfflineStorageOptions | undefined, transport: Transport): void;
-  save(message: string, callback: Function): void;
-  retrieve(callback: Function): void;
-  send(callback: Function): void;
-}
+  save(message: string, callback: (error: Error | null) => void): void;
+  retrieve(
+    callback: (error: NodeJS.ErrnoException | null, items: string[]) => void
+  ): void;
+  send(callback: (error: Error | null, items?: string[]) => void): void;
+};
 
 export type RaygunOptions = {
   apiKey: string;
@@ -161,3 +164,14 @@ export type RaygunOptions = {
   batch?: boolean;
   batchFrequency?: number;
 };
+
+export type CallbackNoError<T> = (t: T) => void;
+export type CallbackWithError<T> = (e: Error | null, t: T | null) => void;
+
+export function isCallbackWithError<T>(
+  cb: Callback<T>
+): cb is CallbackWithError<T> {
+  return cb.length > 1;
+}
+
+export type Callback<T> = CallbackNoError<T> | CallbackWithError<T>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,7 +67,7 @@ export type SendOptions = {
   callback: Function;
   http: HTTPOptions;
   batch: boolean;
-}
+};
 
 export type HTTPOptions = {
   useSSL: boolean;
@@ -75,7 +75,6 @@ export type HTTPOptions = {
   port: number | undefined;
   apiKey: string;
 };
-
 
 export type CustomData = any;
 
@@ -126,4 +125,39 @@ export type OfflineStorageOptions = {
 
 export type Transport = {
   send(message: string, callback?: Function): void;
+};
+
+export type Hook<T> = (
+  message: Message,
+  exception: Error | string,
+  customData: CustomData,
+  request?: RequestParams,
+  tags?: Tag[]
+) => T;
+
+// TODO - it would be nice to be more specific than Function, maybe a union type of the different callback types
+export type IOfflineStorage = {
+  init(options: OfflineStorageOptions | undefined, transport: Transport): void;
+  save(message: string, callback: Function): void;
+  retrieve(callback: Function): void;
+  send(callback: Function): void;
 }
+
+export type RaygunOptions = {
+  apiKey: string;
+  filters?: string[];
+  host?: string;
+  port?: number;
+  useSSL?: boolean;
+  onBeforeSend?: Hook<Message>;
+  offlineStorage?: IOfflineStorage;
+  offlineStorageOptions?: OfflineStorageOptions;
+  isOffline?: boolean;
+  groupingKey?: Hook<string>;
+  tags?: Tag[];
+  useHumanStringForObject?: boolean;
+  reportColumnNumbers?: boolean;
+  innerErrorFieldName?: string;
+  batch?: boolean;
+  batchFrequency?: number;
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -123,3 +123,7 @@ export type OfflineStorageOptions = {
   cachePath: string;
   cacheLimit?: number;
 };
+
+export type Transport = {
+  send(message: string, callback?: Function): void;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -137,8 +137,8 @@ export type Hook<T> = (
   tags?: Tag[]
 ) => T;
 
-export type IOfflineStorage = {
-  init(options: OfflineStorageOptions | undefined, transport: Transport): void;
+export interface IOfflineStorage {
+  init(options: OfflineStorageOptions | undefined): void;
   save(message: string, callback: (error: Error | null) => void): void;
   retrieve(
     callback: (error: NodeJS.ErrnoException | null, items: string[]) => void

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -126,7 +126,7 @@ export type OfflineStorageOptions = {
 };
 
 export type Transport = {
-  send(message: string, callback?: Function): void;
+  send(message: string, callback?: Callback<IncomingMessage>): void;
 };
 
 export type Hook<T> = (
@@ -165,13 +165,21 @@ export type RaygunOptions = {
   batchFrequency?: number;
 };
 
-export type CallbackNoError<T> = (t: T) => void;
+export type CallbackNoError<T> = (t: T | null) => void;
 export type CallbackWithError<T> = (e: Error | null, t: T | null) => void;
 
 export function isCallbackWithError<T>(
   cb: Callback<T>
 ): cb is CallbackWithError<T> {
   return cb.length > 1;
+}
+
+export function callVariadicCallback<T>(callback: Callback<T>, error: Error | null, result: T | null) {
+  if (isCallbackWithError(callback)) {
+    return callback(error, result);
+  } else {
+    return callback(result);
+  }
 }
 
 export type Callback<T> = CallbackNoError<T> | CallbackWithError<T>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -424,6 +424,12 @@
         }
       }
     },
+    "boolean": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
+      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -811,6 +817,12 @@
         "object-keys": "^1.0.12"
       }
     },
+    "delay": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
+      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA==",
+      "dev": true
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -827,6 +839,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
       "dev": true
     },
     "diff": {
@@ -1306,6 +1324,15 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globalthis": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
+      "integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
@@ -1413,6 +1440,16 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "http-terminator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/http-terminator/-/http-terminator-2.0.3.tgz",
+      "integrity": "sha512-2Ete9PUgzNX5hMsx69wRhhzpHc2Mh8kOMz6oJllAxSmJPSDOgnvHE4a6hWlvkwtVJt07ehB1SOt4FfYvM9lrwQ==",
+      "dev": true,
+      "requires": {
+        "delay": "^4.3.0",
+        "roarr": "^2.14.6"
       }
     },
     "iconv-lite": {
@@ -2525,6 +2562,28 @@
         "glob": "^7.1.3"
       }
     },
+    "roarr": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.3.tgz",
+      "integrity": "sha512-AEjYvmAhlyxOeB9OqPUzQCo3kuAkNfuDk/HqWbZdFsqDFpapkTjiw+p4svNEoRLvuqNTxqfL+s+gtD4eDgZ+CA==",
+      "dev": true,
+      "requires": {
+        "boolean": "^3.0.0",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "dev": true
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -2541,6 +2600,12 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "send": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -762,10 +762,9 @@
       "dev": true
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1997,8 +1996,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "negotiator": {
       "version": "0.6.2",
@@ -2033,6 +2031,17 @@
         "propagate": "^1.0.0",
         "qs": "^6.5.1",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "node-modules-regexp": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "verror": "^1.10.0"
   },
   "dependencies": {
+    "debug": "^4.1.1",
     "object-to-human-string": "0.0.3",
     "stack-trace": "0.0.6"
   },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^13.11.1",
     "@types/stack-trace": "0.0.29",
     "express": "^4.17.1",
+    "http-terminator": "^2.0.3",
     "jshint": "^2.5.6",
     "nock": "~9",
     "prettier": "^2.0.4",

--- a/test/raygun_batch_test.js
+++ b/test/raygun_batch_test.js
@@ -1,0 +1,53 @@
+const {test} = require('tap');
+
+const { prepareBatch, MAX_BATCH_SIZE_BYTES } = require('../lib/raygun.batch.ts');
+
+test('batch transport prepares valid json', (t) => {
+  let a, b, c;
+
+  const messages = [
+    {serializedMessage: JSON.stringify(a = {value: 1}), callback: null},
+    {serializedMessage: JSON.stringify(b = {value: []}), callback: null},
+    {serializedMessage: JSON.stringify(c = {value: {nested: true}}), callback: null}
+  ]
+
+  const {payload, messageCount, callbacks} = prepareBatch(messages);
+
+  t.deepEquals(JSON.parse(payload), [a, b, c]);
+
+  t.done();
+});
+
+test('batch transport includes no more than 100 messages', (t) => {
+  const message = JSON.stringify({a: 1});
+  const messages = [];
+
+  for(let i = 0; i < 150; i++) {
+    messages.push({serializedMessage: message, callback: null});
+  }
+
+  const {payload, messageCount, callbacks} = prepareBatch(messages);
+
+  t.equals(messageCount, 100);
+  t.equals(messages.length, 50);
+
+  t.done();
+});
+
+test(`batch transport includes no more than ${MAX_BATCH_SIZE_BYTES} bytes`, (t) => {
+  const messageSize = Math.ceil(MAX_BATCH_SIZE_BYTES / 10);
+  const largeMessage = JSON.stringify({a: '*'.repeat(messageSize - 8)});
+  const messages = [];
+
+  for(let i = 0; i < 100; i++) {
+    messages.push({serializedMessage: largeMessage, callback: null});
+  }
+
+  const {payload, messageCount, callbacks} = prepareBatch(messages);
+
+  t.assert(payload.length <= MAX_BATCH_SIZE_BYTES);
+  t.equals(messageCount, 9);
+  t.equals(messages.length, 91);
+
+  t.done();
+});

--- a/test/raygun_offline_test.js
+++ b/test/raygun_offline_test.js
@@ -1,0 +1,123 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { promisify } = require("util");
+
+const test = require("tap").test;
+
+const { listen, request, makeClientWithMockServer, sleep } = require("./utils");
+
+test("offline message storage and sending", async function (t) {
+  const cachePath = fs.mkdtempSync(path.join(os.tmpdir(), "raygun4node-test"));
+
+  const testEnvironment = await makeClientWithMockServer({
+    isOffline: true,
+    offlineStorageOptions: {
+      cachePath,
+    },
+  });
+  const raygunClient = testEnvironment.client;
+  const send = (e) =>
+    new Promise((resolve, reject) => {
+      raygunClient.send(e, null, (err, data) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      });
+    });
+
+  await send(new Error("offline error"));
+
+  const files = fs.readdirSync(cachePath);
+
+  t.equals(
+    files.length,
+    1,
+    `Expected to find 1 error file but instead found ${files.length}`
+  );
+
+  const file = files[0];
+  const contents = fs.readFileSync(path.join(cachePath, file), "utf-8");
+  const data = JSON.parse(contents);
+
+  t.equals(data.details.error.message, "offline error");
+
+  await send(new Error("offline error 2"));
+
+  await promisify(raygunClient.online.bind(raygunClient))();
+  await testEnvironment.nextRequest();
+  await testEnvironment.nextRequest();
+
+  const filesAfterSend = fs.readdirSync(cachePath);
+
+  t.equals(
+    filesAfterSend.length,
+    0,
+    `Expected to find no stored error files but instead found ${filesAfterSend.length}`
+  );
+
+  testEnvironment.stop();
+  fs.rmdirSync(cachePath);
+});
+
+test("batched offline message storage and sending", async function (t) {
+  const cachePath = fs.mkdtempSync(path.join(os.tmpdir(), "raygun4node-test"));
+
+  const testEnvironment = await makeClientWithMockServer({
+    batch: true,
+    isOffline: true,
+    offlineStorageOptions: {
+      cachePath,
+    },
+  });
+  const raygunClient = testEnvironment.client;
+  const send = (e) =>
+    new Promise((resolve, reject) => {
+      raygunClient.send(e, null, (err, data) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      });
+    });
+
+  await send(new Error("offline error"));
+
+  const files = fs.readdirSync(cachePath);
+
+  t.equals(
+    files.length,
+    1,
+    `Expected to find 1 error file but instead found ${files.length}`
+  );
+
+  const file = files[0];
+  const contents = fs.readFileSync(path.join(cachePath, file), "utf-8");
+  const data = JSON.parse(contents);
+
+  t.equals(data.details.error.message, "offline error");
+
+  await send(new Error("offline error 2"));
+
+  await promisify(raygunClient.online.bind(raygunClient))();
+  const batch = await testEnvironment.nextBatchRequest();
+
+  const filesAfterSend = fs.readdirSync(cachePath);
+
+  t.equals(
+    filesAfterSend.length,
+    0,
+    `Expected to find no stored error files but instead found ${filesAfterSend.length}`
+  );
+
+  t.deepEquals(
+    batch.map((e) => e.details.error.message),
+    ["offline error", "offline error 2"]
+  );
+
+  testEnvironment.stop();
+  fs.rmdirSync(cachePath);
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,8 @@
-const Raygun = require("../lib/raygun");
 const express = require("express");
+const http = require("http");
+const httpTerminator = require('http-terminator').createHttpTerminator;
+
+const Raygun = require("../lib/raygun");
 
 function makeClientWithMockServer(clientOptions = {}) {
   return new Promise((resolve, reject) => {
@@ -8,6 +11,7 @@ function makeClientWithMockServer(clientOptions = {}) {
     const entries = [];
     const bulkEntries = [];
     let messageCallback = null;
+    let batchMessageCallback = null;
 
     server.use(express.json());
     server.post("/entries", (req, res) => {
@@ -23,7 +27,13 @@ function makeClientWithMockServer(clientOptions = {}) {
     });
 
     server.post("/entries/bulk", (req, res) => {
-      bulkEntries.push(JSON.parse(req.body));
+      bulkEntries.push(req.body);
+
+      if (batchMessageCallback) {
+        batchMessageCallback(req.body);
+        batchMessageCallback = null;
+      }
+
       res.send("");
     });
 
@@ -34,21 +44,65 @@ function makeClientWithMockServer(clientOptions = {}) {
         host: "localhost",
         port: address.port,
         useSSL: false,
+        ...clientOptions
       });
 
       resolve({
         client,
         server: { entries, bulkEntries },
-        stop: () => listener.close(() => console.log("test env stopped")),
-        nextRequest: () =>
+        stop: () => {
+          httpTerminator({
+            server: listener
+          }).terminate();
+          client.stop();
+          console.log('trying to stop!');
+        },
+        nextRequest: (options = {maxWait: 10000}) =>
           new Promise((resolve, reject) => {
             messageCallback = resolve;
+            setTimeout(() => reject(new Error(`nextRequest timed out after ${options.maxWait}ms`)), options.maxWait);
+          }),
+        nextBatchRequest: (options = {maxWait: 10000}) =>
+          new Promise((resolve, reject) => {
+            batchMessageCallback = resolve;
+            setTimeout(() => reject(new Error(`nextBatchRequest timed out after ${options.maxWait}ms`)), options.maxWait);
           }),
       });
     });
   });
 }
 
+function request(url) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, (res) => {
+      res.on("end", resolve);
+      res.resume();
+    });
+
+    req.on("error", reject);
+    req.write("");
+    req.end();
+    req.shouldKeepAlive = false;
+  });
+}
+
+function listen(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, "localhost", () => {
+      resolve(server);
+    });
+  });
+}
+
+function sleep(n) {
+  return new Promise((resolve, reject) => {
+    setTimeout(resolve, n);
+  });
+}
+
 module.exports = {
   makeClientWithMockServer,
+  request,
+  listen,
+  sleep
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -55,7 +55,6 @@ function makeClientWithMockServer(clientOptions = {}) {
             server: listener
           }).terminate();
           client.stop();
-          console.log('trying to stop!');
         },
         nextRequest: (options = {maxWait: 10000}) =>
           new Promise((resolve, reject) => {


### PR DESCRIPTION
You can now pass {batch: true} when calling `.init` to enable the batch
transport.

When this option is enabled, errors will be placed in a queue and
processed at a regular interval.

This should cut down on transmission overhead if there are a large
number of errors in short succession.

You can further control the frequency at which batches are processed by
providing a `batchFrequency` option when initializing, which specifies
the interval between batches in milliseconds.

TODO:
- [x] Support offline mode
- [ ] ~~Documentation~~ will be done in a separate PR and merged when changes are released
- [x] More manual testing