### PR TITLE
fix: Move express types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "test": "tap --no-ts --node-arg=-r --node-arg=ts-node/register --no-coverage test/*.js"
   },
   "devDependencies": {
-    "@types/express": "^4.17.6",
     "@types/node": "^13.11.1",
     "@types/stack-trace": "0.0.29",
     "express": "^4.17.1",
@@ -56,6 +55,7 @@
     "verror": "^1.10.0"
   },
   "dependencies": {
+    "@types/express": "^4.17.6",
     "debug": "^4.1.1",
     "object-to-human-string": "0.0.3",
     "stack-trace": "0.0.6",


### PR DESCRIPTION
Since the express types are imported and used in [`raygun.ts`](https://github.com/MindscapeHQ/raygun4node/blob/master/lib/raygun.ts), they should be shipped with raygun. Otherwise the user needs to add the types manually or this error will appear:

```
node_modules/raygun/build/raygun.d.ts(2,54): error TS2307: Cannot find module 'express' or its corresponding type declarations.
```