### PR TITLE
[WIP] Add support for breadcrumbs

### DIFF
--- a/lib/breadcrumbs.ts
+++ b/lib/breadcrumbs.ts
@@ -1,5 +1,6 @@
 import type { AsyncLocalStorage } from "async_hooks";
 import type { Breadcrumb, InternalBreadcrumb } from "./types";
+import path from "path";
 const debug = require("debug")("raygun").bind(null, "[breadcrumbs]");
 
 let asyncLocalStorage: AsyncLocalStorage<InternalBreadcrumb[]> | null = null;
@@ -12,6 +13,47 @@ try {
     "failed to load async_hooks.AsyncLocalStorage - initialization failed\n",
     e
   );
+}
+
+type SourceFile = {
+  fileName: string;
+  functionName: string;
+  lineNumber: number | null;
+};
+
+function returnCallerSite(
+  err: Error,
+  callsites: NodeJS.CallSite[]
+): SourceFile | null {
+  for (const callsite of callsites) {
+    const fileName = callsite.getFileName() || "";
+
+    if (fileName.startsWith(__dirname)) {
+      continue;
+    }
+
+    return {
+      fileName: fileName,
+      functionName: callsite.getFunctionName() || "<anonymous>",
+      lineNumber: callsite.getLineNumber(),
+    };
+  }
+
+  return null;
+}
+
+function getCallsite(): SourceFile | null {
+  const originalPrepareStacktrace = Error.prepareStackTrace;
+
+  Error.prepareStackTrace = returnCallerSite;
+
+  const output: any = {};
+
+  Error.captureStackTrace(output);
+
+  const callsite = output.stack;
+  Error.prepareStackTrace = originalPrepareStacktrace;
+  return callsite;
 }
 
 export function addBreadcrumb(breadcrumb: string | Breadcrumb) {
@@ -33,11 +75,20 @@ export function addBreadcrumb(breadcrumb: string | Breadcrumb) {
     breadcrumb = expandedBreadcrumb;
   }
 
+  const callsite = getCallsite();
+
   const internalCrumb: InternalBreadcrumb = {
     ...(breadcrumb as Breadcrumb),
     timestamp: Number(new Date()),
     type: "manual",
+    className: callsite?.fileName,
+    methodName: callsite?.functionName,
+
+    // TODO - do we need to do any source mapping?
+    lineNumber: callsite?.lineNumber || undefined,
   };
+
+  debug("recorded breadcrumb:", internalCrumb);
 
   crumbs.push(internalCrumb);
 }

--- a/lib/breadcrumbs.ts
+++ b/lib/breadcrumbs.ts
@@ -121,7 +121,17 @@ export function getBreadcrumbs(): InternalBreadcrumb[] | null {
     return null;
   }
 
-  return asyncLocalStorage.getStore() || null;
+  const store = asyncLocalStorage.getStore();
+
+  if (store) {
+    return store;
+  }
+
+  const newStore: InternalBreadcrumb[] = [];
+
+  asyncLocalStorage.enterWith(newStore);
+
+  return newStore;
 }
 
 export function runWithBreadcrumbs(f: () => void) {

--- a/lib/breadcrumbs.ts
+++ b/lib/breadcrumbs.ts
@@ -1,5 +1,6 @@
 import type { AsyncLocalStorage } from "async_hooks";
 import type { Breadcrumb, InternalBreadcrumb } from "./types";
+import type { Request, Response, NextFunction } from "express";
 import path from "path";
 const debug = require("debug")("raygun").bind(null, "[breadcrumbs]");
 
@@ -79,6 +80,9 @@ export function addBreadcrumb(breadcrumb: string | Breadcrumb) {
 
   const internalCrumb: InternalBreadcrumb = {
     ...(breadcrumb as Breadcrumb),
+    category: breadcrumb.category || "",
+    message: breadcrumb.message || "",
+    level: breadcrumb.level || "info",
     timestamp: Number(new Date()),
     type: "manual",
     className: callsite?.fileName,
@@ -89,6 +93,24 @@ export function addBreadcrumb(breadcrumb: string | Breadcrumb) {
   };
 
   debug("recorded breadcrumb:", internalCrumb);
+
+  crumbs.push(internalCrumb);
+}
+
+export function addRequestBreadcrumb(request: Request) {
+  const crumbs = getBreadcrumbs();
+
+  if (!crumbs) {
+    return;
+  }
+
+  const internalCrumb: InternalBreadcrumb = {
+    category: "http",
+    message: `${request.method} ${request.url}`,
+    level: "info",
+    timestamp: Number(new Date()),
+    type: "request",
+  };
 
   crumbs.push(internalCrumb);
 }

--- a/lib/breadcrumbs.ts
+++ b/lib/breadcrumbs.ts
@@ -1,0 +1,61 @@
+import type { AsyncLocalStorage } from "async_hooks";
+import type { Breadcrumb, InternalBreadcrumb } from "./types";
+const debug = require("debug")("raygun").bind(null, "[breadcrumbs]");
+
+let asyncLocalStorage: AsyncLocalStorage<InternalBreadcrumb[]> | null = null;
+
+try {
+  asyncLocalStorage = new (require("async_hooks").AsyncLocalStorage)();
+  debug("initialized successfully");
+} catch (e) {
+  debug(
+    "failed to load async_hooks.AsyncLocalStorage - initialization failed\n",
+    e
+  );
+}
+
+export function addBreadcrumb(breadcrumb: string | Breadcrumb) {
+  debug("adding breadcrumb:", breadcrumb);
+
+  const crumbs = getBreadcrumbs();
+
+  if (!crumbs) {
+    return;
+  }
+
+  if (typeof breadcrumb === "string") {
+    const expandedBreadcrumb: Breadcrumb = {
+      message: breadcrumb,
+      level: "info",
+      category: "",
+    };
+
+    breadcrumb = expandedBreadcrumb;
+  }
+
+  const internalCrumb: InternalBreadcrumb = {
+    ...(breadcrumb as Breadcrumb),
+    timestamp: Number(new Date()),
+    type: "manual",
+  };
+
+  crumbs.push(internalCrumb);
+}
+
+export function getBreadcrumbs(): InternalBreadcrumb[] | null {
+  if (!asyncLocalStorage) {
+    return null;
+  }
+
+  return asyncLocalStorage.getStore() || null;
+}
+
+export function runWithBreadcrumbs(f: () => void) {
+  if (!asyncLocalStorage) {
+    f();
+    return;
+  }
+  debug("running function with breadcrumbs");
+
+  asyncLocalStorage.run([], f);
+}

--- a/lib/raygun.batch.ts
+++ b/lib/raygun.batch.ts
@@ -62,9 +62,11 @@ export class RaygunBatchTransport {
   }
 
   private process() {
-    debug(
-      `batch transport - processing (${this.messageQueue.length} message(s) in queue)`
-    );
+    if (this.messageQueue.length > 0) {
+      debug(
+        `batch transport - processing (${this.messageQueue.length} message(s) in queue)`
+      );
+    }
 
     const { payload, messageCount, callbacks } = prepareBatch(
       this.messageQueue

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -296,6 +296,14 @@ class Raygun {
     }
   }
 
+  breadcrumbs(req: Request, res: Response, next: NextFunction) {
+    runWithBreadcrumbs(next);
+  }
+
+  addBreadcrumb(b: string | Breadcrumb) {
+    addBreadcrumb(b);
+  }
+
   private buildSendOptions(
     exception: Error | string,
     customData?: CustomData,
@@ -412,11 +420,6 @@ class Raygun {
       },
     };
   }
-
-  addBreadcrumb(b: string | Breadcrumb) {
-    addBreadcrumb(b);
-  }
-
   private offlineStorage(): IOfflineStorage {
     let storage = this._offlineStorage;
 

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -9,6 +9,7 @@
 "use strict";
 
 import {
+  Breadcrumb,
   callVariadicCallback,
   Callback,
   CustomData,
@@ -27,6 +28,11 @@ import {
 import type { IncomingMessage } from "http";
 import type { Request, Response, NextFunction } from "express";
 import { RaygunBatchTransport } from "./raygun.batch";
+import {
+  addBreadcrumb,
+  getBreadcrumbs,
+  runWithBreadcrumbs,
+} from "./breadcrumbs";
 import { RaygunMessageBuilder } from "./raygun.messageBuilder";
 import { OfflineStorage } from "./raygun.offline";
 import { startTimer } from "./timer";
@@ -351,6 +357,8 @@ class Raygun {
       return { valid: false, message };
     }
 
+    message.details.breadcrumbs = getBreadcrumbs() || [];
+
     function wrappedCallback(
       error: Error | null,
       response: IncomingMessage | null
@@ -405,6 +413,10 @@ class Raygun {
     };
   }
 
+  addBreadcrumb(b: string | Breadcrumb) {
+    addBreadcrumb(b);
+  }
+
   private offlineStorage(): IOfflineStorage {
     let storage = this._offlineStorage;
 
@@ -422,4 +434,5 @@ class Raygun {
 
 export const Client = Raygun;
 export type Client = Raygun;
-export default { Client };
+export { addBreadcrumb, runWithBreadcrumbs };
+export default { Client, addBreadcrumb, runWithBreadcrumbs };

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -30,6 +30,7 @@ import type { Request, Response, NextFunction } from "express";
 import { RaygunBatchTransport } from "./raygun.batch";
 import {
   addBreadcrumb,
+  addRequestBreadcrumb,
   getBreadcrumbs,
   runWithBreadcrumbs,
 } from "./breadcrumbs";
@@ -297,7 +298,10 @@ class Raygun {
   }
 
   breadcrumbs(req: Request, res: Response, next: NextFunction) {
-    runWithBreadcrumbs(next);
+    runWithBreadcrumbs(() => {
+      addRequestBreadcrumb(req);
+      next();
+    });
   }
 
   addBreadcrumb(b: string | Breadcrumb) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -51,6 +51,7 @@ export type MessageDetails = {
   machineName: string;
   environment: Environment;
   correlationId: string | null;
+  breadcrumbs?: InternalBreadcrumb[];
 };
 
 export type Environment = {
@@ -194,3 +195,27 @@ export function callVariadicCallback<T>(
 }
 
 export type Callback<T> = CallbackNoError<T> | CallbackWithError<T>;
+
+export type Serializable =
+  | number
+  | null
+  | string
+  | Serializable[]
+  | { [key: string]: Serializable };
+
+export type InternalBreadcrumb = {
+  timestamp: number;
+  level: "debug" | "info" | "warning" | "error";
+  type: "manual" | "navigation" | "click-event" | "request" | "console";
+  category: string;
+  message: string;
+  customData?: Serializable;
+  className?: string;
+  methodName?: string;
+  lineNumber?: number;
+};
+
+export type Breadcrumb = Pick<
+  InternalBreadcrumb,
+  "level" | "category" | "message" | "customData"
+>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -215,7 +215,6 @@ export type InternalBreadcrumb = {
   lineNumber?: number;
 };
 
-export type Breadcrumb = Pick<
-  InternalBreadcrumb,
-  "level" | "category" | "message" | "customData"
+export type Breadcrumb = Partial<
+  Pick<InternalBreadcrumb, "level" | "category" | "message" | "customData">
 >;

--- a/test/raygun_breadcrumbs_test.js
+++ b/test/raygun_breadcrumbs_test.js
@@ -1,0 +1,37 @@
+const express = require("express");
+const test = require("tap").test;
+const { runWithBreadcrumbs } = require("../lib/raygun");
+const { listen, makeClientWithMockServer, request } = require("./utils");
+
+test("capturing breadcrumbs", async function (t) {
+  const app = express();
+  const testEnv = await makeClientWithMockServer();
+  const raygun = testEnv.client;
+
+  app.use((req, res, next) => {
+    runWithBreadcrumbs(next);
+  });
+
+  app.get("/", (req, res) => {
+    raygun.addBreadcrumb("first!");
+    setTimeout(() => {
+      raygun.addBreadcrumb("second!");
+      raygun.send(new Error("test end"));
+      res.send("done!");
+    }, 1);
+  });
+
+  const server = await listen(app);
+
+  await request(`http://localhost:${server.address().port}`);
+  const message = await testEnv.nextRequest();
+
+  server.close();
+  testEnv.stop();
+
+  t.assert(
+    message.details.breadcrumbs.map((b) => b.message),
+    ["first!", "second!"]
+  );
+  t.pass();
+});

--- a/test/raygun_breadcrumbs_test.js
+++ b/test/raygun_breadcrumbs_test.js
@@ -30,21 +30,21 @@ test("capturing breadcrumbs", async function (t) {
 
   t.deepEquals(
     message.details.breadcrumbs.map((b) => b.message),
-    ["first!", "second!"]
+    ["GET /", "first!", "second!"]
   );
 
   t.deepEquals(
     message.details.breadcrumbs.map((b) => b.methodName),
-    [requestHandler.name, "<anonymous>"]
+    [undefined, requestHandler.name, "<anonymous>"]
   );
 
   t.deepEquals(
     message.details.breadcrumbs.map((b) => b.className),
-    [__filename, __filename]
+    [undefined, __filename, __filename]
   );
 
   t.deepEquals(
     message.details.breadcrumbs.map((b) => b.lineNumber),
-    [13, 15]
+    [undefined, 13, 15]
   );
 });

--- a/test/raygun_breadcrumbs_test.js
+++ b/test/raygun_breadcrumbs_test.js
@@ -1,6 +1,5 @@
 const express = require("express");
 const test = require("tap").test;
-const { runWithBreadcrumbs } = require("../lib/raygun");
 const { listen, makeClientWithMockServer, request } = require("./utils");
 
 test("capturing breadcrumbs", async function (t) {
@@ -8,9 +7,7 @@ test("capturing breadcrumbs", async function (t) {
   const testEnv = await makeClientWithMockServer();
   const raygun = testEnv.client;
 
-  app.use((req, res, next) => {
-    runWithBreadcrumbs(next);
-  });
+  app.use(raygun.breadcrumbs);
 
   function requestHandler(req, res) {
     raygun.addBreadcrumb("first!");
@@ -48,6 +45,6 @@ test("capturing breadcrumbs", async function (t) {
 
   t.deepEquals(
     message.details.breadcrumbs.map((b) => b.lineNumber),
-    [16, 18]
+    [13, 15]
   );
 });

--- a/test/raygun_express_test.js
+++ b/test/raygun_express_test.js
@@ -4,14 +4,14 @@ var test = require("tap").test;
 var { listen, request, makeClientWithMockServer } = require("./utils");
 
 test("reporting express errors", async function (t) {
+  t.plan(1);
   const app = express();
 
   const testEnvironment = await makeClientWithMockServer();
   const raygunClient = testEnvironment.client;
 
-  app.get("/", (req, res) => {
+  app.get("/", () => {
     throw new Error("surprise error!");
-    res.send("response!");
   });
 
   app.use(raygunClient.expressHandler);

--- a/test/raygun_express_test.js
+++ b/test/raygun_express_test.js
@@ -1,9 +1,7 @@
 var express = require("express");
 var test = require("tap").test;
 
-var { listen, request, makeClientWithMockServer, sleep } = require("./utils");
-
-var API_KEY = "apikey";
+var { listen, request, makeClientWithMockServer } = require("./utils");
 
 test("reporting express errors", async function (t) {
   const app = express();

--- a/test/utils.js
+++ b/test/utils.js
@@ -59,19 +59,21 @@ function makeClientWithMockServer(clientOptions = {}) {
         },
         nextRequest: (options = { maxWait: 10000 }) =>
           new Promise((resolve, reject) => {
-            messageCallback = resolve;
-            setTimeout(
+            const cancelId = setTimeout(
               () =>
                 reject(
                   new Error(`nextRequest timed out after ${options.maxWait}ms`)
                 ),
               options.maxWait
             );
+            messageCallback = function (message) {
+              clearTimeout(cancelId);
+              resolve(message);
+            };
           }),
         nextBatchRequest: (options = { maxWait: 10000 }) =>
           new Promise((resolve, reject) => {
-            batchMessageCallback = resolve;
-            setTimeout(
+            const cancelId = setTimeout(
               () =>
                 reject(
                   new Error(
@@ -80,6 +82,10 @@ function makeClientWithMockServer(clientOptions = {}) {
                 ),
               options.maxWait
             );
+            batchMessageCallback = function (message) {
+              clearTimeout(cancelId);
+              resolve(message);
+            };
           }),
       });
     });


### PR DESCRIPTION
Currently built on top of `AsyncLocalStorage`, which means that we can run a section of code with a particular scope for breadcrumbs, which allows us to process multiple requests in parallel and still attribute breadcrumbs correctly without a great deal of user intervention.

Note that `AsyncLocalStorage` is only available on Node `12.17+` and onwards. An implementation that provides this sort of behaviour for earlier Node versions would have to rely on either re-implementing `AsyncLocalStorage` by hand with async hooks, or using Domains, which is [not always a good idea](https://nodejs.org/en/docs/guides/domain-postmortem/).

I personally see this as an acceptable tradeoff, as it provides support for the latest version of all LTS builds, and as currently implemented it simply does nothing on earlier versions.

Todo:
 - [x] Populate className, methodName and lineNumber if possible
 - [x] Dedicated express middleware
 - [ ] User API for re-entering a breadcrumb scope (after a DB request for example)
 - [ ] Investigate re-using async hook patches from `raygun-apm`
 - [ ] Documentation
 - [ ] More comprehensive unit testing
 - [ ] Warn if Node version doesn't support `AsyncLocalStorage`