### PR TITLE
Fix raygunClient.user not being called if request is missing

### DIFF
--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -122,7 +122,7 @@ class Raygun {
     return this;
   }
 
-  user(req: Request): RawUserData | null {
+  user(req?: Request): RawUserData | null {
     return null;
   }
 
@@ -245,7 +245,7 @@ class Raygun {
       .setMachineName()
       .setEnvironmentDetails()
       .setUserCustomData(customData)
-      .setUser((request && this.user(request)) || this._user)
+      .setUser(this.user(request) || this._user)
       .setVersion(this._version)
       .setTags(mergedTags);
 

--- a/test/raygun_express_test.js
+++ b/test/raygun_express_test.js
@@ -93,3 +93,22 @@ test("exceptions are propagated by middleware", async function (t) {
   server.close();
   testEnvironment.stop();
 });
+
+test("user function is called even if request is not present", async function (t) {
+  t.plan(1);
+
+  const testEnvironment = await makeClientWithMockServer();
+  const raygunClient = testEnvironment.client;
+
+  raygunClient.user = () => ({ email: "test@null.null" });
+
+  const nextRequest = testEnvironment.nextRequest();
+
+  raygunClient.send(new Error("example error"));
+
+  const message = await nextRequest;
+
+  testEnvironment.stop();
+
+  t.deepEquals(message.details.user, { email: "test@null.null" });
+});


### PR DESCRIPTION
This is a fix for a regression I introduced during the TypeScript
overhaul.

Previously we would always call this.user, even if the request was null
or undefined. The regressed behavior would only call this.user if the
request was present, either from the middleware or if it was passed
manually.

This commit reverts the behavior back to what it was previously, and
adds a unit test to guard against future unintended changes to this
behaviour.