### PR TITLE
[Customers Product]: Change references from 'Users' to 'Customers' within documentation 👥

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 - Added ability to send tags with exception reports
 
 ## 0.5.0
-- Added filters for sensitive request data, and better affected user tracking
+- Added filters for sensitive request data, and better affected user tracking/Customers
 
 ## 0.4.2
 - Minor test refactor
@@ -88,7 +88,7 @@
 - Added *user* function, deprecated setUser
 
 ## 0.3.0
-- Added version and user tracking functionality; bump jshint version, update test
+- Added version and user tracking/Customers functionality; bump jshint version, update test
 
 ## 0.2.0
 - Added Express handler, bug fixes

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Tags can also be set globally using setTags
 client.setTags(['Tag1', 'Tag2']);
 ```
 
-### Affected user tracking
+### Customers
 
 New in 0.4: You can set **raygunClient.user** to a function that returns the user name or email address of the currently logged in user.
 
@@ -168,11 +168,11 @@ raygunClient.user = function (req) {
 **Param**: *req*: the current request.
 **Returns**: The current user's identifier, or an object that describes the user.
 
-This will be transmitted with each message sent, and a count of affected users will appear on the dashboard in the error group view. If you return an email address, and the user has associated a Gravatar with it, their picture will be also displayed.
+This will be transmitted with each message sent, and a count of affected customers will appear on the dashboard in the error group view. If you return an email address, and the user has associated a Gravatar with it, their picture will be also displayed.
 
 If you return an object, it may have any of the following properties (only identifier is required):
 
-`identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using user tracking.
+`identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using Customers.
 
 `isAnonymous` is a bool indicating whether the user is anonymous or actually has a user account. Even if this is set to true, you should still give the user a unique identifier of some kind.
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This will be transmitted with each message sent, and a count of affected custome
 
 If you return an object, it may have any of the following properties (only identifier is required):
 
-`identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using Customers.
+`identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using customers tracking.
 
 `isAnonymous` is a bool indicating whether the user is anonymous or actually has a user account. Even if this is set to true, you should still give the user a unique identifier of some kind.
 


### PR DESCRIPTION
## [Customers Product]: Change references from 'User tracking' to 'Customers' 👤

**NOTE: This is not to be merged until we have fully released the name change in the Raygun application. Changes to 'users' within the code needs to be discussed and planned for.**

### Description 📝 
This PR is to updating the name convention for 'User tracking' to now be 'Customers' to reflect what's within the Raygun application.

**Updates**
👉 Update `README` documentation
👉 Update `CHANGELOG`

### Test plan 🧪 
- Make sure documentation changes are reflected to be 'Customers' instead of 'User Tracking'

### Checklist ✔️ 
- [ ] Builds pass
- [ ] Reviewed by another developer
- [ ] Code is written to standards