### PR TITLE
Export Raygun.Client type

### DIFF
--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -318,4 +318,5 @@ class Raygun {
 }
 
 export const Client = Raygun;
-export default {Client};
+export type Client = Raygun;
+export default { Client };


### PR DESCRIPTION
Allows our customers to make use of our type definitions.

With this change in place, this example works as expected:

```
import * as Raygun from "raygun4node";

class Example {
  _raygun: Raygun.Client;

  constructor() {
    this._raygun = new Raygun.Client().init({apiKey: 'foo'});
  }
}
```

Unfortunately, this still doesn't work for the `import Raygun from "raygun4node"' case, as TypeScript will still report that it can't find a namespace called "Raygun".

It seems like TypeScript doesn't have great support for typing default exports, at least the way we have this set up. I think this could be improved but would likely be a breaking change, so this is probably a good place to start.