### PR TITLE
Fix exception formatting when passing string to send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.13.1
+- Fix format of exceptions when calling `raygunClient.send` with a string value
+
 ## 0.13.0
 - Fatal errors can now be reported to Raygun by enabling the  `reportUncaughtExceptions` when initializing the client
 

--- a/lib/raygun.messageBuilder.ts
+++ b/lib/raygun.messageBuilder.ts
@@ -141,6 +141,8 @@ export class RaygunMessageBuilder {
     if (typeof error === "string") {
       this.message.details.error = {
         message: error,
+        stackTrace: [],
+        className: "Error",
       };
 
       return this;

--- a/lib/raygun.messageBuilder.ts
+++ b/lib/raygun.messageBuilder.ts
@@ -127,7 +127,11 @@ export class RaygunMessageBuilder {
   }
 
   setErrorDetails(error: any) {
-    if (!(error instanceof Error) && this.options.useHumanStringForObject) {
+    if (
+      !(error instanceof Error) &&
+      typeof error !== "string" &&
+      this.options.useHumanStringForObject
+    ) {
       error = humanString(error);
       this.message.details.groupingKey = error
         .replace(/\W+/g, "")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "raygun",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun.io package for Node, written in TypeScript",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "MindscapeHQ",

--- a/test/raygun.messageBuilder_test.js
+++ b/test/raygun.messageBuilder_test.js
@@ -58,6 +58,16 @@ test("basic builder tests", function (t) {
     tt.end();
   });
 
+  t.test("humanise leaves strings intact", function (tt) {
+    var builder = new MessageBuilder({ useHumanStringForObject: true });
+    builder.setErrorDetails("my awesome error");
+
+    var message = builder.build();
+    tt.notOk(message.details.groupingKey);
+    tt.equal("my awesome error", message.details.error.message);
+    tt.end();
+  });
+
   t.test("dont humanise string", function (tt) {
     var builder = new MessageBuilder({ useHumanStringForObject: false });
     builder.setErrorDetails({ name: "Test" });

--- a/test/raygun_express_test.js
+++ b/test/raygun_express_test.js
@@ -117,3 +117,20 @@ test("user function is called even if request is not present", async function (t
 
   t.same(message.details.user, { email: "test@null.null" });
 });
+
+test("string exceptions are sent intact", async function (t) {
+  t.plan(1);
+
+  const testEnvironment = await makeClientWithMockServer();
+  const raygunClient = testEnvironment.client;
+
+  const nextRequest = testEnvironment.nextRequest();
+
+  raygunClient.send("my string error");
+
+  const message = await nextRequest;
+
+  testEnvironment.stop();
+
+  t.same(message.details.error.message, "my string error");
+});


### PR DESCRIPTION
Previously, when calling raygunClient.send("test"), the exception would be formatted as if we had sent raygunClient.send(["t", "e", "s", "t"]).

This was as a result of passing the error value to humanString, which is intending for serializing objects and arrays in a pleasant way.

This change avoids applying any formatting to exceptions passed as a string.

I've also included a release commit so that we can promptly publish after merging.

Fixes #114 

