### PR TITLE
Fix batch transport keeping process alive

### DIFF
--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -117,7 +117,6 @@ class Raygun {
           apiKey: this._apiKey,
         },
       });
-      this._batchTransport.startProcessing();
     }
 
     this.expressHandler = this.expressHandler.bind(this);

--- a/test/fixtures/batch_lifecycle.js
+++ b/test/fixtures/batch_lifecycle.js
@@ -1,0 +1,8 @@
+require("ts-node/register");
+const raygun = require("../../lib/raygun");
+
+// this exists entirely to test that using the batch transport doesn't keep the node process alive unnecessarily
+const raygunClient = new raygun.Client().init({
+  apiKey: "example!",
+  batch: true,
+});

--- a/test/raygun_batch_lifecycle_test.js
+++ b/test/raygun_batch_lifecycle_test.js
@@ -1,0 +1,20 @@
+const { test } = require("tap");
+const { exec } = require("child_process");
+
+test("batch transport doesn't keep processes alive", async (t) => {
+  await new Promise((resolve, reject) => {
+    const process = exec(
+      "node test/fixtures/batch_lifecycle.js",
+      (error, stdout, stderr) => {
+        if (error) {
+          console.log(stdout);
+          console.error(stderr);
+          return reject(error);
+        }
+
+        t.assert(process.exitCode === 0);
+        resolve();
+      }
+    );
+  });
+});


### PR DESCRIPTION
Previously, using batch: true would keep the process alive indefinitely due to the use of setInterval.

This is often okay for webapps which run until killed or crashed, but causes problems when using crash reporting in a short-lived script.

This commit replaces the interval based process loop with one based on setInterval.

The timer is now inactive until messages are queued for sending, at which point we activate the timer loop.

Process will send batches, and restart the loop if there are any remaining messages. If not, the loop will stop until new messages come in.

Fixes #122