### PR TITLE
Fix massive errors causing batch processing stalls

### DIFF
--- a/lib/raygun.batch.ts
+++ b/lib/raygun.batch.ts
@@ -127,6 +127,18 @@ export function prepareBatch(
 
     const { serializedMessage, callback } = messageQueue[0];
 
+    if (serializedMessage.length >= MAX_BATCH_INNER_SIZE_BYTES) {
+      const messageSize = Math.ceil(serializedMessage.length / 1024);
+      const startOfMessage = serializedMessage.slice(0, 1000);
+
+      console.warn(
+        `[raygun4node] Error is too large to send to Raygun (${messageSize}kb)\nStart of error: ${startOfMessage}`
+      );
+
+      messageQueue.shift();
+      continue;
+    }
+
     if (
       batchSizeBytes + serializedMessage.length >
       MAX_BATCH_INNER_SIZE_BYTES
@@ -135,6 +147,7 @@ export function prepareBatch(
     }
 
     batch.push(serializedMessage);
+
     if (callback) {
       callbacks.push(callback);
     }


### PR DESCRIPTION
Previously, if we attempted to send a massive error (>1600kb) via batch
mode, it would stall all batch processing.

This can cause all sorts of problems. Now, we dicard any messages this
large and log a warning.

This is better than the alternative behaviour of attempting to send
anyway, as the Raygun API will disconnect us if we intend to send that
much data, which causes an annoying EPIPE error.