### PR TITLE
ci: Create node.js.yml

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm test


### PR DESCRIPTION
This PR adds the GitHub Actions workflow:

- Run on Node 16.x (deprecated), 18.x (current maintenance), 20.x (current active) according to https://nodejs.org/en/about/previous-releases
- Runs commands `npm ci` which compiles and installs the server.
- And command `npm test` which runs the tests.
- Results are posted in the PR.
- Tested on my fork.

e.g.
![image](https://github.com/MindscapeHQ/raygun4node/assets/2494376/4fe29f39-b703-4c50-b5b2-420f4b4551d9)
