### PR TITLE
chore: adding PR, bug report and feature request templates

### DIFF
--- a/.github/bug_report.md
+++ b/.github/bug_report.md
@@ -30,5 +30,8 @@ If applicable, add screenshots to help explain your problem.
  - SDK version: [e.g. 10.5.2]
  - Node/npm versions: [e.g. 21.7.3]
 
-**Additional context**
-Add any other context about the problem here.
+## Logs
+If applicable, include relevant logs or error messages here (please use code blocks to format properly).
+
+## Possible Solution
+If you have suggestions for how the issue might be resolved or investigated, please describe them here.

--- a/.github/bug_report.md
+++ b/.github/bug_report.md
@@ -30,8 +30,8 @@ If applicable, add screenshots to help explain your problem.
  - SDK version: [e.g. 10.5.2]
  - Node/npm versions: [e.g. 21.7.3]
 
-## Logs
+** Logs**
 If applicable, include relevant logs or error messages here (please use code blocks to format properly).
 
-## Possible Solution
+**Possible Solution**
 If you have suggestions for how the issue might be resolved or investigated, please describe them here.

--- a/.github/bug_report.md
+++ b/.github/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Bug report
+title: "<Area of the SDK>: <Short Description of issue>"
+labels: needs triage
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+Links to related tickets or other context are welcome here.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Linux/Windows/macOS etc]
+ - SDK version: [e.g. 10.5.2]
+ - Node/npm versions: [e.g. 21.7.3]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/feature_request.md
+++ b/.github/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: A new feature for this SDK
+title: "<Area of the SDK>: <Short Description of new feature>"
+labels: needs triage
+assignees: ''
+
+---
+
+**Please describe your new feature request**
+A clear and concise description of what the problem is. Example: I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+Links to related tickets or other information are welcome here.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,41 @@
+## [{ticket number/type}:] {title}
+
+### Description :memo:
+{Description}
+
+**Type of change**
+
+*Delete options that are not relevant.*
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+**Updates**
+
+:point_right:
+:point_right:
+:point_right:
+
+### Screenshots :camera:
+{Image here of before and after - if applicable}
+
+### Test plan :test_tube:
+*Provide guidance for how to QA your proposed changes. This is not only for a test but also useful for a reviewer.*
+
+{A test plan outlining scenarios to test}
+
+### Author to check :eyeglasses:
+- [ ] Project and all contained modules builds successfully
+- [ ] Self-/dev-tested 
+- [ ] Unit/UI/Automation/Integration tests provided where applicable
+- [ ] Code is written to standards
+- [ ] Appropriate documentation written (code comments, internal docs)
+
+### Reviewer to check :heavy_check_mark:
+- [ ] Project and all contained modules builds successfully
+- [ ] Change has been dev-/reviewer-tested, where possible
+- [ ] Unit/UI/Automation/Integration tests provided where applicable
+- [ ] Code is written to standards
+- [ ] Appropriate documentation written (code comments, internal docs)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,8 @@
 ## [{ticket number/type}:] {title}
 
 ### Description :memo:
-{Description}
+- **Purpose**: What issue does this PR address or what feature does it implement?
+- **Approach**: How does this PR tackle the problem?
 
 **Type of change**
 


### PR DESCRIPTION
Adding some process templates as a starting point. We can tweak further down the track, but this will help streamline flows as well as internal/external requests.