### PR TITLE
ci: add PR title checks

### DIFF
--- a/.github/pr.yml
+++ b/.github/pr.yml
@@ -1,0 +1,37 @@
+name: "Pull-Request Check"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+            Details:
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
## ci: add PR title checks

### Description :memo:
- **Purpose**: Enforce the user of Conventional Commits in PR titles
- **Approach**: Adds a GitHub Actions configuration that runs on PR creation and update

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**Updates**

- Added `pr.yml` configuration file.
- The file contains the GitHub Actions configuration, with the following steps:
  1. Checks if the PR title is valid
  2. If not, it adds an info message
  3. If then is fixed, the info message is removed

### Test plan :test_tube:

- Needs to be merged into `develop` to see it in action.
- Uses a standard template found in other repos so it should work the same.

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [x] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)