### PR TITLE
refactor: #158 remove no-useless-catch eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,8 +29,6 @@ export default tseslint.config(
             ],
             // Required to import JS modules
             "@typescript-eslint/no-var-requires": "off",
-            // TODO: Remove ignored rules and fix the code
-            "no-useless-catch": "off",
         }
     }
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,7 +30,6 @@ export default tseslint.config(
             // Required to import JS modules
             "@typescript-eslint/no-var-requires": "off",
             // TODO: Remove ignored rules and fix the code
-            "no-unreachable": "off",
             "no-useless-catch": "off",
         }
     }

--- a/test/raygun_express_test.js
+++ b/test/raygun_express_test.js
@@ -42,8 +42,6 @@ test("batch reporting errors", async function (t) {
 
   try {
     await nextBatchRequest({ maxWait: 2000 });
-  } catch (e) {
-    throw e;
   } finally {
     stop();
   }
@@ -68,8 +66,6 @@ test("batch transport discards massive errors", async function (t) {
 
   try {
     await nextBatchRequest({ maxWait: 2000 });
-  } catch (e) {
-    throw e;
   } finally {
     stop();
   }

--- a/test/raygun_express_test.js
+++ b/test/raygun_express_test.js
@@ -12,7 +12,6 @@ test("reporting express errors", async function (t) {
 
   app.get("/", (req, res) => {
     throw new Error("surprise error!");
-    res.send("response!");
   });
 
   app.use(raygunClient.expressHandler);
@@ -102,7 +101,6 @@ test("exceptions are propagated by middleware", async function (t) {
 
   app.get("/", (req, res) => {
     throw new Error("surprise error!");
-    res.send("response!");
   });
 
   function testErrorHandler(err, req, res, next) {


### PR DESCRIPTION
## refactor: #158 remove no-useless-catch eslint rule

### Description :memo:
- **Purpose**: Remove the `no-useless-catch` eslint rule ignore setting
- **Approach**: Remove rule and fix code
- **Depends on**: #177

- This change also concludes the `eslint` setup.
- Closes #158 

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Removed rule from `eslint.config.mjs`
- Removed the useless `catch` statements.
  - A `catch` and `throw` is not necessary, since we can just throw the original error, and the `finally` block will be called anyway.

### Test plan :test_tube:

- Rerun the tests and eslint process.
- Only test files were affected.

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)