### PR TITLE
fix: #186 avoid infinite recursion in filter method

### DIFF
--- a/lib/raygun.messageBuilder.ts
+++ b/lib/raygun.messageBuilder.ts
@@ -58,14 +58,10 @@ function filterKeys(
     // Remove child if:
     // - the key is in the filter array
     // - the value is already in the explored Set
-    if (filters.indexOf(key) > -1 || _explored?.has(_obj[key])) {
+    if (filters.indexOf(key) > -1 || _explored.has(_obj[key])) {
       delete _obj[key];
     } else {
-      _obj[key] = filterKeys(
-        _obj[key],
-        filters,
-        _explored,
-      );
+      _obj[key] = filterKeys(_obj[key], filters, _explored);
     }
   });
   return _obj;

--- a/lib/raygun.messageBuilder.ts
+++ b/lib/raygun.messageBuilder.ts
@@ -31,18 +31,28 @@ type UserMessageData = RawUserData | string | undefined;
 const humanString = require("object-to-human-string");
 const packageDetails = require("../package.json");
 
-function filterKeys(obj: object, filters: string[], explored: Set<object> | null): object {
+function filterKeys(
+  obj: object,
+  filters: string[],
+  explored: Set<object> | null = null,
+): object {
+  // check if obj has been explored to avoid infinite recursion
   if (!obj || !filters || typeof obj !== "object" || explored?.has(obj)) {
     return obj;
   }
-  // Make temporary copy of the object to avoid mutating the original
+
   // Cast to Record<string, object> to enforce type check and avoid using any
-  const _obj = { ...obj } as Record<string, object>;
+  const _obj = obj as Record<string, object>;
   Object.keys(obj).forEach(function (i) {
     if (filters.indexOf(i) > -1) {
       delete _obj[i];
     } else {
-      _obj[i] = filterKeys(_obj[i], filters, explored?.add(_obj) || new Set([_obj]));
+      // add current obj to explored set before recursive call
+      _obj[i] = filterKeys(
+        _obj[i],
+        filters,
+        explored?.add(_obj) || new Set([_obj]),
+      );
     }
   });
   return _obj;

--- a/lib/raygun.messageBuilder.ts
+++ b/lib/raygun.messageBuilder.ts
@@ -31,8 +31,8 @@ type UserMessageData = RawUserData | string | undefined;
 const humanString = require("object-to-human-string");
 const packageDetails = require("../package.json");
 
-function filterKeys(obj: object, filters: string[]): object {
-  if (!obj || !filters || typeof obj !== "object") {
+function filterKeys(obj: object, filters: string[], explored: Set<object> | null): object {
+  if (!obj || !filters || typeof obj !== "object" || explored?.has(obj)) {
     return obj;
   }
   // Make temporary copy of the object to avoid mutating the original
@@ -42,7 +42,7 @@ function filterKeys(obj: object, filters: string[]): object {
     if (filters.indexOf(i) > -1) {
       delete _obj[i];
     } else {
-      _obj[i] = filterKeys(_obj[i], filters);
+      _obj[i] = filterKeys(_obj[i], filters, explored?.add(_obj) || new Set([_obj]));
     }
   });
   return _obj;

--- a/lib/raygun.messageBuilder.ts
+++ b/lib/raygun.messageBuilder.ts
@@ -37,7 +37,6 @@ function filterKeys(
   explored: Set<object> | null = null,
 ): object {
   // check if obj has been explored to avoid infinite recursion
-
   if (!obj || !filters || typeof obj !== "object" || explored?.has(obj)) {
     return obj;
   }

--- a/lib/raygun.messageBuilder.ts
+++ b/lib/raygun.messageBuilder.ts
@@ -37,21 +37,23 @@ function filterKeys(
   explored: Set<object> | null = null,
 ): object {
   // check if obj has been explored to avoid infinite recursion
+
   if (!obj || !filters || typeof obj !== "object" || explored?.has(obj)) {
     return obj;
   }
 
+  // Make temporary copy of the object to avoid mutating the original
   // Cast to Record<string, object> to enforce type check and avoid using any
-  const _obj = obj as Record<string, object>;
+  const _obj = { ...obj } as Record<string, object>;
   Object.keys(obj).forEach(function (i) {
     if (filters.indexOf(i) > -1) {
       delete _obj[i];
     } else {
-      // add current obj to explored set before recursive call
+      // add original obj to explored set before recursive call
       _obj[i] = filterKeys(
         _obj[i],
         filters,
-        explored?.add(_obj) || new Set([_obj]),
+        explored?.add(obj) || new Set([obj]),
       );
     }
   });

--- a/test/raygun.messageBuilder_test.js
+++ b/test/raygun.messageBuilder_test.js
@@ -399,6 +399,30 @@ test("filter keys tests", function (t) {
   });
 });
 
+test("avoid infinite recursion in filter method", function (t) {
+  let builder = new MessageBuilder();
+
+  // body self-references, causing a potential infinite recursion in the filter method
+  // Causes exception: Maximum call stack size exceeded
+  let body = {
+    "key": "value",
+  };
+  body.myself = body;
+
+  let queryString = {};
+  let headers = {};
+
+  // performs filter on set
+  builder.setRequestDetails({
+    body: body,
+    query: queryString,
+    headers: headers,
+  });
+
+  // test should finish
+  t.end();
+});
+
 test("custom tags", function (t) {
   t.test("with array", function (tt) {
     var builder = new MessageBuilder();

--- a/test/raygun.messageBuilder_test.js
+++ b/test/raygun.messageBuilder_test.js
@@ -405,7 +405,7 @@ test("avoid infinite recursion in filter method", function (t) {
   // body self-references, causing a potential infinite recursion in the filter method
   // Causes exception: Maximum call stack size exceeded
   let body = {
-    "key": "value",
+    key: "value",
   };
   body.myself = body;
 

--- a/test/raygun.messageBuilder_test.js
+++ b/test/raygun.messageBuilder_test.js
@@ -377,6 +377,10 @@ test("filter keys tests", function (t) {
   });
   var message = builder.build();
 
+  // Original object should not be modified
+  t.equal(body.username, "admin@raygun.io");
+  t.equal(body.password, "nice try");
+
   t.test("form is filtered", function (tt) {
     tt.equal(message.details.request.form.username, undefined);
     tt.equal(message.details.request.form.password, undefined);


### PR DESCRIPTION
## fix: #186 avoid infinite recursion in filter method

### Description :memo:
- **Purpose**: `filterKeys` method uses recursion to explore the provided object, this can potentially cause infinite recursion and eventually throw the "Maximum call stack size exceeded" error.
- **Approach**: Adds an `explored` parameter to the recursive `filterKeys` method, to check if the incoming object has already been explored or not.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- TDD approach: Created a test that can reproduce the issue, using a cyclic object, and causes a "Maximum call stack size exceeded" error, then implemented the solution to fix it.
- Implementation:
  - Added `explored: Set<object>` as parameter (it is `null` by default).
  - When iterating over the object children, if the child is in the explored `Set`, remove from parent. Same as when applying filters.
  - When calling to `filterKeys` recursively, include the explored object in the `Set`.
- After performing the changes, the test passes.
- Also added a test assert to ensure that the original object is not modified.

One decision I had to make, is if the self-referenced object should be included in the output or not.

My decision to remove it from the output, is that we cannot apply filtering to the properties of the self-referenced object. Remember that we are doing a copy because we don't want to modify the original.

example of input from the test:

```
{
  myself: *self reference*,
  key: "value",
  filtered: true,
  other: {
    body: *self reference*,
    filtered: true,
  }
}
```

output would be:
```
{
  key: "value",
  other: { }
}
```

After removing all filtered properties and self-referenced objects.

### Test plan :test_tube:

- Method is unit tested with a new test, also existing tests pass.

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)