### PR TITLE
chore: apply prettier to all files in examples

### DIFF
--- a/examples/express-sample/bin/www
+++ b/examples/express-sample/bin/www
@@ -4,16 +4,16 @@
  * Module dependencies.
  */
 
-var app = require('../app');
-var debug = require('debug')('express-sample:server');
-var http = require('http');
+var app = require("../app");
+var debug = require("debug")("express-sample:server");
+var http = require("http");
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
-app.set('port', port);
+var port = normalizePort(process.env.PORT || "3000");
+app.set("port", port);
 
 /**
  * Create HTTP server.
@@ -26,8 +26,8 @@ var server = http.createServer(app);
  */
 
 server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
+server.on("error", onError);
+server.on("listening", onListening);
 
 /**
  * Normalize a port into a number, string, or false.
@@ -54,22 +54,26 @@ function normalizePort(val) {
  */
 
 function onError(error) {
-  if (error.syscall !== 'listen') {
+  if (error.syscall !== "listen") {
     throw error;
   }
 
-  var bind = typeof port === 'string'
-    ? 'Pipe ' + port
-    : 'Port ' + port
+  var bind = typeof port === "string" ? "Pipe " + port : "Port " + port;
 
   // handle specific listen errors with friendly messages
   switch (error.code) {
-    case 'EACCES':
-      console.error(`[Raygun4Node-Express-Sample] ` + bind + ` requires elevated privileges`);
+    case "EACCES":
+      console.error(
+        `[Raygun4Node-Express-Sample] ` +
+          bind +
+          ` requires elevated privileges`,
+      );
       process.exit(1);
       break;
-    case 'EADDRINUSE':
-      console.error(`[Raygun4Node-Express-Sample] ` + bind + ` is already in use`);
+    case "EADDRINUSE":
+      console.error(
+        `[Raygun4Node-Express-Sample] ` + bind + ` is already in use`,
+      );
       process.exit(1);
       break;
     default:
@@ -83,8 +87,6 @@ function onError(error) {
 
 function onListening() {
   var addr = server.address();
-  var bind = typeof addr === 'string'
-    ? 'pipe ' + addr
-    : 'port ' + addr.port;
-  debug('Listening on ' + bind);
+  var bind = typeof addr === "string" ? "pipe " + addr : "port " + addr.port;
+  debug("Listening on " + bind);
 }

--- a/examples/express-sample/config/default.json
+++ b/examples/express-sample/config/default.json
@@ -1,5 +1,5 @@
 {
-	"Raygun": {
-		"Key": "YOUR_API_KEY"
-	}
+  "Raygun": {
+    "Key": "YOUR_API_KEY"
+  }
 }

--- a/examples/express-sample/config/production.json
+++ b/examples/express-sample/config/production.json
@@ -1,5 +1,5 @@
 {
-	"Raygun": {
-		"Key": "YOUR_PRODUCTION_API_KEY"
-	}
+  "Raygun": {
+    "Key": "YOUR_PRODUCTION_API_KEY"
+  }
 }

--- a/examples/express-sample/public/stylesheets/style.css
+++ b/examples/express-sample/public/stylesheets/style.css
@@ -1,8 +1,12 @@
 body {
   padding: 50px;
-  font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
+  font:
+    14px "Lucida Grande",
+    Helvetica,
+    Arial,
+    sans-serif;
 }
 
 a {
-  color: #00B7FF;
+  color: #00b7ff;
 }

--- a/examples/express-sample/public/stylesheets/style.scss
+++ b/examples/express-sample/public/stylesheets/style.scss
@@ -2,9 +2,13 @@
 
 body {
   padding: 50px;
-  font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
+  font:
+    14px "Lucida Grande",
+    Helvetica,
+    Arial,
+    sans-serif;
 }
 
 a {
-  color: #00B7FF;
+  color: #00b7ff;
 }

--- a/examples/using-domains/config/default.json
+++ b/examples/using-domains/config/default.json
@@ -1,5 +1,5 @@
 {
-	"Raygun":{
-		"Key":"YOUR_API_KEY"
-	}
+  "Raygun": {
+    "Key": "YOUR_API_KEY"
+  }
 }

--- a/examples/using-domains/config/production.json
+++ b/examples/using-domains/config/production.json
@@ -1,5 +1,5 @@
 {
-	"Raygun":{
-		"Key":"Your_Production_API_Key"
-	}
+  "Raygun": {
+    "Key": "Your_Production_API_Key"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "//eslint": "performs static analysis over project files and examples",
     "eslint": "eslint --fix lib/*.ts test/*.js examples/**/*.js",
     "//prettier": "performs code formatting over project files and examples",
-    "prettier": "prettier --write lib/*.ts test/*.js examples/**/*.js",
+    "prettier": "prettier --write lib/*.ts test/*.js examples",
     "//prepare": "prepare project for distribution",
     "prepare": "tsc",
     "//test": "runs tests on main project",


### PR DESCRIPTION
## chore: apply prettier to all files in examples

### Description :memo:
- **Purpose**: Ensure that non-dot-js files are also formatted correctly
- **Approach**: Apply prettier to all files in the `examples` directory
- Closes #204 

**Type of change**

- [x] Chore

**Updates**

- Update command in `package.json`.
- Apply prettier command.

### Test plan :test_tube:

- GitHub CI should pass.

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)