### PR TITLE
fix: #137 Report unhandled rejection promises automatically

### DIFF
--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -337,8 +337,20 @@ class Raygun {
       return;
     }
 
+    // Handles uncaught exceptions, e.g. missing try/catch on a throw.
     process.on("uncaughtExceptionMonitor", (e) => {
-      this.sendSync(e);
+      this.sendSync(e, ["uncaughtException"]);
+    });
+
+    // Handles uncaught Promise rejections, e.g. missing .catch(...) on a Promise.
+    // Unhandled Promise rejections are not caught by the "uncaughtExceptionMonitor".
+    process.on("unhandledRejection", (reason, promise) => {
+      if (reason instanceof Error || typeof reason === "string") {
+        this.sendSync(reason, ["unhandledRejection"]);
+      } else {
+        // `reason` type is unknown, wrap in String
+        this.sendSync(`Unhandled Rejection: ${reason}`, ["unhandledRejection"]);
+      }
     });
   }
 
@@ -346,10 +358,11 @@ class Raygun {
    * Send error using synchronous transport.
    * Only used to report uncaught exceptions.
    * @param exception error to report
+   * @param tags optional tags
    * @private
    */
-  private sendSync(exception: Error | string): void {
-    const result = this.buildSendOptions(exception);
+  private sendSync(exception: Error | string, tags?: Tag[]): void {
+    const result = this.buildSendOptions(exception, null, undefined, tags);
 
     if (result.valid) {
       raygunSyncTransport.send(result.options);

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -356,7 +356,7 @@ class Raygun {
 
   /**
    * Send error using synchronous transport.
-   * Only used to report uncaught exceptions.
+   * Only used internally to report uncaught exceptions or unhandled promises.
    * @param exception error to report
    * @param tags optional tags
    * @private

--- a/test/raygun_unhandled_rejection_app.js
+++ b/test/raygun_unhandled_rejection_app.js
@@ -1,0 +1,19 @@
+const Raygun = require("../");
+const API_KEY = process.env.RAYGUN_API_KEY;
+const API_PORT = process.env.RAYGUN_API_PORT;
+
+new Raygun.Client().init({
+  apiKey: API_KEY,
+  host: "localhost",
+  port: API_PORT,
+  useSSL: false,
+  reportUncaughtExceptions: true,
+});
+
+// Run a Promise without .catch()
+new Promise(() => {
+  // Cause an error
+  throw new Error("test");
+}).then(() => {
+  // Should not be reached
+});

--- a/test/raygun_unhandled_rejection_test.js
+++ b/test/raygun_unhandled_rejection_test.js
@@ -12,7 +12,7 @@ test("reporting uncaught exceptions", async function (t) {
 
   await util
     .promisify(childProcess.exec)(
-      "node -r ts-node/register ./raygun_uncaught_exception_app.js",
+      "node -r ts-node/register ./raygun_unhandled_rejection_app.js",
       {
         cwd: __dirname,
         stdio: "inherit",
@@ -30,7 +30,7 @@ test("reporting uncaught exceptions", async function (t) {
   testEnvironment.stop();
 
   t.equal(message.details.error.message, "test");
-  // Ensure that the error was reported by the uncaughtExceptionMonitor listener
-  deepEqual(message.details.tags, ["uncaughtException"]);
+  // Ensure that the error was reported by the unhandledRejection listener
+  deepEqual(message.details.tags, ["unhandledRejection"]);
   t.end();
 });


### PR DESCRIPTION
## fix: #137 Report unhandled rejection promises automatically

### Description :memo:
- **Purpose**: When a user forgets to `.catch()` a Promise, and this fails, Raygun4Node will capture the error and send it automatically
- **Approach**: Similar to the uncaught exception handler, but for Promises, using `unhandledRejection`.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Added `process.on` handler.
- Added tags to the `sendSync` method, to help differentiate between "uncaught exceptions" and "unhandled rejections".
- Implemented test.

### Test plan :test_tube:

- Verified using unit tests.
- Verified running simple app:

```js
// Setup Raygun
var raygun = require("raygun");
var raygunClient = new raygun.Client().init({ apiKey: config.Raygun.Key, reportUncaughtExceptions: true });

new Promise(() => {
  throw new Error("test");
}).then(() => {
  // Should not be reached
});
```

![image](https://github.com/MindscapeHQ/raygun4node/assets/2494376/f73820ba-3472-4b54-b211-c82e98cd3268)


### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)