### PR TITLE
chore: Prepare release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.1.0
+
+- feat: Part of #220 add internal runWithBreadcrumbsAsync function (#245) (2024-06-05)
+- fix: onBeforeSend allows to skip messages (#231) (2024-05-28)
+- chore(deps-dev): bump @eslint/js from 9.3.0 to 9.4.0 (#243) (2024-06-03)
+- chore(deps-dev): bump @types/node from 20.12.12 to 20.14.0 (#242) (2024-06-03)
+- chore(deps-dev): bump prettier from 3.2.5 to 3.3.0 (#241) (2024-06-03)
+- chore(deps): bump debug from 4.3.4 to 4.3.5 (#240) (2024-06-03)
+- chore(deps-dev): bump typescript-eslint from 7.10.0 to 7.11.0 (#239) (2024-06-03)
+- chore(deps-dev): bump tap from 18.8.0 to 19.0.2 (#237) (2024-05-28)
+- chore(deps-dev): bump typescript-eslint from 7.9.0 to 7.10.0 (2024-05-27)
+
 ## 1.0.0
 
 - feat: #219 Better Send parameters (#221) (2024-05-17)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raygun",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raygun",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@types/express": "^4.17.21",
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun package for Node.js, written in TypeScript",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "Raygun",


### PR DESCRIPTION
## chore: Prepare release 1.1.0

### Description :memo:
- **Purpose**: Prepare release 1.1.0
- **Approach**: Update package version and changelog

**Type of change**

- [x] Chore task

**Updates**

- Generate CHANGELOG entry, order by feat -> fix -> chore.
- Bump version in `package.json` to `1.1.0`.
- Run `npm install` to update `package-lock.json`.

### Test plan :test_tube:

Run `npm publish --dry-run`:

```
➜  raygun4node git:(prepare-1.1.0) npm publish --dry-run

> raygun@1.1.0 prepare
> tsc

npm notice
npm notice 📦  raygun@1.1.0
npm notice Tarball Contents
npm notice 5.3kB CHANGELOG.md
npm notice 20.8kB README.md
npm notice 0B build/.gitkeep
npm notice 1.2kB build/raygun.batch.d.ts
npm notice 6.1kB build/raygun.batch.js
npm notice 470B build/raygun.breadcrumbs.d.ts
npm notice 204B build/raygun.breadcrumbs.express.d.ts
npm notice 942B build/raygun.breadcrumbs.express.js
npm notice 4.2kB build/raygun.breadcrumbs.js
npm notice 4.1kB build/raygun.d.ts
npm notice 21.0kB build/raygun.js
npm notice 900B build/raygun.messageBuilder.d.ts
npm notice 9.1kB build/raygun.messageBuilder.js
npm notice 657B build/raygun.offline.d.ts
npm notice 3.7kB build/raygun.offline.js
npm notice 257B build/raygun.sync.transport.d.ts
npm notice 1.1kB build/raygun.sync.transport.js
npm notice 11B build/raygun.sync.worker.d.ts
npm notice 1.7kB build/raygun.sync.worker.js
npm notice 522B build/raygun.transport.d.ts
npm notice 2.4kB build/raygun.transport.js
npm notice 52B build/timer.d.ts
npm notice 408B build/timer.js
npm notice 4.8kB build/types.d.ts
npm notice 509B build/types.js
npm notice 2.1kB package.json
npm notice Tarball Details
npm notice name: raygun
npm notice version: 1.1.0
npm notice filename: raygun-1.1.0.tgz
npm notice package size: 24.8 kB
npm notice unpacked size: 92.6 kB
npm notice shasum: 800b135b2cc864fa48841d16b5a296703f8878f9
npm notice integrity: sha512-3oGCtc7lTuqWw[...]IB7Wg9K7PKaPg==
npm notice total files: 26
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ raygun@1.1.0
```

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [x] Project and all contained modules builds successfully
- [x] Change has been dev-/reviewer-tested, where possible
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)