### PR TITLE
feat: #65 Custom timestamp parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ client.setTags(['Tag1', 'Tag2']);
 You can specify the exact time your error occurred in the Send() function with the `timestamp` parameter.
 Otherwise, the current time will be used.
 
+This can be useful when combining Raygun together with other logger tools that provide a timestamp.
+
 In milliseconds since epoch:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -201,6 +201,23 @@ Tags can also be set globally using setTags
 client.setTags(['Tag1', 'Tag2']);
 ```
 
+### Timestamp
+
+You can specify the exact time your error occurred in the Send() function with the `timestamp` parameter.
+Otherwise, the current time will be used.
+
+In milliseconds since epoch:
+
+```javascript
+client.send(new Error(), { timestamp: 1718268992929 });
+```
+
+As `Date` object:
+
+```javascript
+client.send(new Error(), { timestamp: new Date(2024, 5, 13, 10, 0, 0) });
+```
+
 ### Customers
 
 New in 0.4: You can set **raygunClient.user** to a function that returns the user name or email address of the currently logged in user.

--- a/lib/raygun.messageBuilder.ts
+++ b/lib/raygun.messageBuilder.ts
@@ -137,7 +137,7 @@ export class RaygunMessageBuilder {
     this._filters = options.filters || [];
 
     this.message = {
-      occurredOn: new Date(),
+      occurredOn: options.timestamp || new Date(),
       details: {
         client: {
           name: "raygun-node",

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -233,17 +233,19 @@ class Raygun {
    * @param customData to attach to the error report.
    * @param request custom RequestParams.
    * @param tags to attach to the error report.
+   * @param timestamp to provide a custom timestamp as Date object.
    * @return IncomingMessage if message was delivered, null if stored, rejected with Error if failed.
    */
   async send(
     exception: Error | string,
-    { customData, request, tags }: SendParameters = {},
+    { customData, request, tags, timestamp }: SendParameters = {},
   ): Promise<IncomingMessage | null> {
     const sendOptionsResult = this.buildSendOptions(
       exception,
       customData,
       request,
       tags,
+      timestamp,
     );
 
     const message = sendOptionsResult.message;
@@ -475,6 +477,7 @@ class Raygun {
     customData?: CustomData,
     request?: RequestParams,
     tags?: Tag[],
+    timestamp?: Date,
   ): SendOptionsResult {
     let mergedTags: Tag[] = [];
     let skip = false;
@@ -492,6 +495,7 @@ class Raygun {
       useHumanStringForObject: this._useHumanStringForObject,
       reportColumnNumbers: this._reportColumnNumbers,
       innerErrorFieldName: this._innerErrorFieldName,
+      timestamp: timestamp,
     })
       .setErrorDetails(exception)
       .setRequestDetails(request)

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -241,7 +241,8 @@ class Raygun {
     { customData, request, tags, timestamp }: SendParameters = {},
   ): Promise<IncomingMessage | null> {
     // Convert timestamp in milliseconds since epoch to Date
-    const _timestamp = typeof timestamp === "number" ? new Date(timestamp) : timestamp;
+    const _timestamp =
+      typeof timestamp === "number" ? new Date(timestamp) : timestamp;
 
     const sendOptionsResult = this.buildSendOptions(
       exception,

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -233,19 +233,22 @@ class Raygun {
    * @param customData to attach to the error report.
    * @param request custom RequestParams.
    * @param tags to attach to the error report.
-   * @param timestamp to provide a custom timestamp as Date object.
+   * @param timestamp to provide a custom timestamp as Date object or number in milliseconds since epoch.
    * @return IncomingMessage if message was delivered, null if stored, rejected with Error if failed.
    */
   async send(
     exception: Error | string,
     { customData, request, tags, timestamp }: SendParameters = {},
   ): Promise<IncomingMessage | null> {
+    // Convert timestamp in milliseconds since epoch to Date
+    const _timestamp = typeof timestamp === "number" ? new Date(timestamp) : timestamp;
+
     const sendOptionsResult = this.buildSendOptions(
       exception,
       customData,
       request,
       tags,
-      timestamp,
+      _timestamp,
     );
 
     const message = sendOptionsResult.message;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,7 @@ export type MessageBuilderOptions = {
   useHumanStringForObject?: boolean;
   innerErrorFieldName?: string;
   filters?: string[];
+  timestamp?: Date;
 };
 
 export type StackFrame = {
@@ -222,4 +223,5 @@ export interface SendParameters {
   customData?: CustomData;
   request?: RequestParams;
   tags?: Tag[];
+  timestamp?: Date;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -223,5 +223,5 @@ export interface SendParameters {
   customData?: CustomData;
   request?: RequestParams;
   tags?: Tag[];
-  timestamp?: Date;
+  timestamp?: Date | number;
 }

--- a/test/raygun.messageBuilder_test.js
+++ b/test/raygun.messageBuilder_test.js
@@ -81,6 +81,19 @@ test("basic builder tests", function (t) {
   });
 });
 
+test("custom timestamp", function (t) {
+  const timestamp = new Date(2024, 1, 2, 3, 45, 12, 345);
+  const builder = new MessageBuilder({ timestamp });
+  const message = builder.build();
+
+  t.test("occurred on is custom timestamp", function (tt) {
+    tt.equal(message.occurredOn, timestamp);
+    tt.end();
+  });
+
+  t.end();
+});
+
 test("error builder tests", function (t) {
   var builder = new MessageBuilder();
   builder.setErrorDetails(new Error());

--- a/test/raygun_async_send_test.js
+++ b/test/raygun_async_send_test.js
@@ -204,7 +204,7 @@ test("send with expressHandler custom data", function (t) {
   client.expressHandler(new Error(), {}, {}, function () {});
 });
 
-test("provide custom timestamp to send", {}, function (t) {
+test("provide custom timestamp as date to send", {}, function (t) {
   let client = new Raygun.Client().init({ apiKey: "TEST" });
   const timestamp = new Date(2024, 1, 2, 3, 45, 12, 345);
 
@@ -221,4 +221,24 @@ test("provide custom timestamp to send", {}, function (t) {
     .catch((err) => {
       t.fail(err);
     });
+});
+
+test("provide custom timestamp as number to send", {}, function (t) {
+  let client = new Raygun.Client().init({ apiKey: "TEST" });
+  const date = new Date(2024, 1, 2, 3, 45, 12, 345);
+  const timestamp = date.getTime();
+
+  client.onBeforeSend(function (payload) {
+    t.same(payload.occurredOn, date);
+    return payload;
+  });
+
+  client
+      .send(new Error(), { timestamp })
+      .then((message) => {
+        t.end();
+      })
+      .catch((err) => {
+        t.fail(err);
+      });
 });

--- a/test/raygun_async_send_test.js
+++ b/test/raygun_async_send_test.js
@@ -234,11 +234,11 @@ test("provide custom timestamp as number to send", {}, function (t) {
   });
 
   client
-      .send(new Error(), { timestamp })
-      .then((message) => {
-        t.end();
-      })
-      .catch((err) => {
-        t.fail(err);
-      });
+    .send(new Error(), { timestamp })
+    .then((message) => {
+      t.end();
+    })
+    .catch((err) => {
+      t.fail(err);
+    });
 });

--- a/test/raygun_async_send_test.js
+++ b/test/raygun_async_send_test.js
@@ -203,3 +203,22 @@ test("send with expressHandler custom data", function (t) {
   };
   client.expressHandler(new Error(), {}, {}, function () {});
 });
+
+test("provide custom timestamp to send", {}, function (t) {
+  let client = new Raygun.Client().init({ apiKey: "TEST" });
+  const timestamp = new Date(2024, 1, 2, 3, 45, 12, 345);
+
+  client.onBeforeSend(function (payload) {
+    t.same(payload.occurredOn, timestamp);
+    return payload;
+  });
+
+  client
+    .send(new Error(), { timestamp })
+    .then((message) => {
+      t.end();
+    })
+    .catch((err) => {
+      t.fail(err);
+    });
+});


### PR DESCRIPTION
## feat: #65 Custom timestamp parameter

### Description :memo:
- **Purpose**: Adds functionality for custom timestamp when reporting errors, requested in #65
- **Approach**: Adds the `timestamp` parameter to the `send()` method as optional config param.
- Closes #65 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**Updates**

- Add `timestamp` to `SendParameters`.
- `timestamp` uses the standard `Date` type or can be passed as `number`.
- Implemented tests
- Updated README docs

### Test plan :test_tube:

- Tested in example.
- Implement tests

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)