### PR TITLE
docs: #196 add documentation on handling errors in sync transport

### DIFF
--- a/lib/raygun.sync.transport.ts
+++ b/lib/raygun.sync.transport.ts
@@ -31,8 +31,11 @@ export function send(options: SendOptions) {
   try {
     syncRequest(options);
   } catch (e) {
-    // TODO: Is there a reason we ignore errors here?
-    console.log(
+    // Catch all errors from a synchronous request and display them in the console
+    // This synchronous transport is only used internally to report internal errors,
+    // i.e. uncaught exceptions and unhandled rejection promises.
+    // We need to handle any exceptions internally because the users cannot process these.
+    console.error(
       `[Raygun4Node] Error ${e} occurred while attempting to send error with message: ${options.message}`,
     );
   }


### PR DESCRIPTION
## doc: #196 add documentation on handling errors in sync transport

### Description :memo:
- **Purpose**: Adds clarification to why the sync transport catches all errors internally
- **Approach**: Add comments and console error log
- Closes: #196 
- To merge after 1.1.0 is released.

**Type of change**

- [x] Documentation

**Updates**

- Removes old TODO comment.
- Add explanation comment
- Change `console.log` to `console.error`.

### Test plan :test_tube:

- None

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [x] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)