### PR TITLE
refactor: #199 batch callbacks

### DIFF
--- a/lib/raygun.batch.ts
+++ b/lib/raygun.batch.ts
@@ -5,22 +5,27 @@ import { HTTPOptions, SendOptions } from "./types";
 
 const debug = require("debug")("raygun");
 
-export type MessageAndCallback = {
+export type MessageAndPromise = {
   serializedMessage: string;
-  resolve: (message: IncomingMessage) => void;
-  reject: (error: Error) => void;
+  promise: PromiseReference<IncomingMessage>;
 };
 
 export type PreparedBatch = {
   payload: string;
   messageCount: number;
-  resolves: Array<(message: IncomingMessage) => void>;
-  rejects: Array<(error: Error) => void>;
+  promises: Array<PromiseReference<IncomingMessage>>;
 };
 
 export type BatchState = {
-  messages: MessageAndCallback[];
+  messages: MessageAndPromise[];
   messageSizeInBytes: number;
+};
+
+// Contains the resolve and reject methods of the original promise
+// Allows to call to resolve and reject from outside the Promise scope
+type PromiseReference<T> = {
+  resolve: (message: T) => void;
+  reject: (error: Error) => void;
 };
 
 export const MAX_MESSAGES_IN_BATCH = 100;
@@ -96,7 +101,8 @@ export class RaygunBatchTransport {
     }
 
     const promise = new Promise<IncomingMessage>((resolve, reject) => {
-      this.batchState.messages.push({ serializedMessage, resolve, reject });
+      const promise = { resolve, reject };
+      this.batchState.messages.push({ serializedMessage, promise });
     });
 
     const batchIsFull = this.batchState.messages.length === 100;
@@ -116,8 +122,7 @@ export class RaygunBatchTransport {
     const batch: PreparedBatch = {
       payload: `[${payload}]`,
       messageCount: this.batchState.messages.length,
-      resolves: this.batchState.messages.map((m) => m.resolve),
-      rejects: this.batchState.messages.map((m) => m.reject),
+      promises: this.batchState.messages.map((m) => m.promise),
     };
 
     this.sendBatch(batch);
@@ -128,7 +133,7 @@ export class RaygunBatchTransport {
   }
 
   private sendBatch(batch: PreparedBatch) {
-    const { payload, messageCount, resolves, rejects } = batch;
+    const { payload, messageCount, promises } = batch;
 
     debug(
       `[raygun.batch.ts] Batch transport - processing (${messageCount} message(s) in batch)`,
@@ -138,7 +143,7 @@ export class RaygunBatchTransport {
 
     this.batchId++;
 
-    const runAllCallbacks = (
+    const resolvePromises = (
       err: Error | null,
       response: IncomingMessage | null,
     ) => {
@@ -147,17 +152,15 @@ export class RaygunBatchTransport {
         debug(
           `[raygun.batch.ts] Batch transport - error sending batch (id=${batchId}, duration=${durationInMs}ms): ${err}`,
         );
-        for (const reject of rejects) {
-          reject(err);
+        for (const promise of promises) {
+          promise.reject(err);
         }
       } else {
         debug(
           `[raygun.batch.ts] Batch transport - successfully sent batch (id=${batchId}, duration=${durationInMs}ms)`,
         );
-        if (response) {
-          for (const resolve of resolves) {
-            resolve(response);
-          }
+        for (const promise of promises) {
+          promise.resolve(response!);
         }
       }
     };
@@ -173,12 +176,10 @@ export class RaygunBatchTransport {
       http: this.httpOptions,
     })
       .then((response) => {
-        // Call to original callbacks for success
-        runAllCallbacks(null, response);
+        resolvePromises(null, response);
       })
       .catch((error) => {
-        // Call to original callbacks for error
-        runAllCallbacks(error, null);
+        resolvePromises(error, null);
       });
   }
 }

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -312,6 +312,8 @@ class Raygun {
 
   /**
    * @deprecated sendWithCallback is a deprecated method. Instead, use send, which supports async/await calls.
+   *
+   * See: https://github.com/MindscapeHQ/raygun4node/issues/262
    */
   sendWithCallback(
     exception: Error | string,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -174,6 +174,8 @@ export type RaygunOptions = {
   reportUncaughtExceptions?: boolean;
 };
 
+// TODO: Remove all Callback related types when sendWithCallback is finally removed
+// See: https://github.com/MindscapeHQ/raygun4node/issues/262
 export type CallbackNoError<T> = (t: T | null) => void;
 export type CallbackWithError<T> = (e: Error | null, t: T | null) => void;
 

--- a/test/raygun_express_test.js
+++ b/test/raygun_express_test.js
@@ -55,14 +55,22 @@ test("batch reporting errors", async function (t) {
 });
 
 test("batch transport discards massive errors", async function (t) {
+  t.plan(5);
   const { client, server, stop, nextBatchRequest } =
     await makeClientWithMockServer({
       batch: true,
       batchFrequency: 1000,
     });
 
-  client.send(new Error("a".repeat(MAX_BATCH_SIZE_BYTES)));
-  client.send(new Error("b"));
+  client.send(new Error("a".repeat(MAX_BATCH_SIZE_BYTES))).catch((error) => {
+    // Will throw message too big error
+    t.ok(error);
+  });
+
+  client.send(new Error("b")).then((message) => {
+    // Will complete normally
+    t.ok(message);
+  });
 
   try {
     await nextBatchRequest({ maxWait: 2000 });


### PR DESCRIPTION
## refactor: #199 batch callbacks

### Description :memo:
- **Purpose**: Cleanup batch processing callbacks 
- **Approach**: Removing the old callback type, replacing it by an alternative based on Promises
- Closes #199 

**Type of change**

- [x] Refactor

**Updates**

- Created `PromiseReference` to handle the promise's `reject` and `resolve` methods.
- Replaced `Callback` with `PromiseReference`.
- Improved the tests

Note: The original `Callback` type should be eventually removed

### Test plan :test_tube:

- Implement unit tests.
- Run express example with `batch: true` to test batch processing

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [x] Project and all contained modules builds successfully
- [x] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)