### PR TITLE
feat: #218 Optional `userInfo` in `send()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,12 +237,11 @@ This package offers three different ways to do that:
 
 The following properties can be provided as user information:
 
-- `identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using customers tracking.
-- `uuid` is the identifier of the device the app is running on. This could be used to correlate user accounts over multiple machines.
-- `firstName` is the user's first or preferred name.
-- `lastName` is the user's surname name.
-- `fullName` is the user's full name.
-- `email` is the user's email address.
+- `identifier`: Unique identifier for the user is the user identifier.
+- `email`: User's email address.
+- `firstName`: User's first name (what you would use if you were emailing them - "Hi {{firstName}}, ...")
+- `fullName`: User's full name.
+- `uuid`: Device unique identifier. Useful if sending errors from a mobile device.
 
 All properties are `strings`. Any other properties will be discarded.
 
@@ -252,10 +251,16 @@ Example:
 userInfo = {
     identifier: "123",
     email: "user@example.com",
-    fullName: "Fullname",
     firstName: "First name",
+    fullName: "Fullname",
     uuid: "a25dfe58-8db3-496c-8768-375595139375",
 }
+```
+
+For legacy support reasons, you can also provide the `string` identifier directly as the user information:
+
+```js
+setUser("123");
 ```
 
 #### `userInfo` parameter in `send()`

--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ This package offers three different ways to do that:
 The following properties can be provided as user information:
 
 - `identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using customers tracking.
-- `isAnonymous` is a bool indicating whether the user is anonymous or actually has a user account. Even if this is set to true, you should still give the user a unique identifier of some kind.
-- `email` is the user's email address.
-- `fullName` is the user's full name.
-- `firstName` is the user's first or preferred name.
 - `uuid` is the identifier of the device the app is running on. This could be used to correlate user accounts over multiple machines.
+- `firstName` is the user's first or preferred name.
+- `lastName` is the user's surname name.
+- `fullName` is the user's full name.
+- `email` is the user's email address.
 
 All properties are `strings`. Any other properties will be discarded.
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ backwards compatibility; the Node-style callback should be preferred.
 The `send()` method accepts a series of optional named parameters, defined as follows:
 
 ```js
-client.send(error, { customData, request, tags });
+client.send(error, { customData, request, tags, timestamp, userInfo });
 ```
 
 Each one of these parameters is optional.
@@ -222,7 +222,55 @@ client.send(new Error(), { timestamp: new Date(2024, 5, 13, 10, 0, 0) });
 
 ### Customers
 
-New in 0.4: You can set **raygunClient.user** to a function that returns the user name or email address of the currently logged in user.
+You can attach user information to every Raygun Crash Report.
+
+It will be transmitted with the error sent, and a count of affected customers will appear on the dashboard in the error group view.
+If you provide an email address, and the user has associated a Gravatar with it, their picture will be also displayed.
+
+This package offers three different ways to do that:
+
+1. Provide the `userInfo` parameter in the `send()` method.
+2. Implement the `user(request)` method.
+3. Call to the `setUser(user)` method (not recommended and deprecated).
+
+#### User information object
+
+The following properties can be provided as user information:
+
+- `identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using customers tracking.
+- `isAnonymous` is a bool indicating whether the user is anonymous or actually has a user account. Even if this is set to true, you should still give the user a unique identifier of some kind.
+- `email` is the user's email address.
+- `fullName` is the user's full name.
+- `firstName` is the user's first or preferred name.
+- `uuid` is the identifier of the device the app is running on. This could be used to correlate user accounts over multiple machines.
+
+All properties are `strings`. Any other properties will be discarded.
+
+Example:
+
+```js
+userInfo = {
+    identifier: "123",
+    email: "user@example.com",
+    fullName: "Fullname",
+    firstName: "First name",
+    uuid: "a25dfe58-8db3-496c-8768-375595139375",
+}
+```
+
+#### `userInfo` parameter in `send()`
+
+Provide the `userInfo` optional parameter in the `send()` method call:
+
+```javascript
+client.send(new Error(), { userInfo });
+```
+
+This provided user information will take priority over the `user(request)` and `setUser(user)` methods.
+
+#### Implement `raygunClient.user(req)`
+
+You can set `raygunClient.user` to a function that returns the user name or email address of the currently logged in user.
 
 An example, using the Passport.js middleware:
 
@@ -242,32 +290,15 @@ raygunClient.user = function (req) {
 }
 ```
 
-#### raygunClient.user(req)
-
 **Param**: *req*: the current request.
 **Returns**: The current user's identifier, or an object that describes the user.
 
-This will be transmitted with each message sent, and a count of affected customers will appear on the dashboard in the error group view. If you return an email address, and the user has associated a Gravatar with it, their picture will be also displayed.
+#### Global `setUser(user)` method
 
-If you return an object, it may have any of the following properties (only identifier is required):
+You can set the user information globally by calling `setUser(user)` and providing the user information.
 
-`identifier` is the user identifier. This will be used to uniquely identify the user within Raygun. This is the only required parameter, but is only required if you are using customers tracking.
-
-`isAnonymous` is a bool indicating whether the user is anonymous or actually has a user account. Even if this is set to true, you should still give the user a unique identifier of some kind.
-
-`email` is the user's email address.
-
-`fullName` is the user's full name.
-
-`firstName` is the user's first or preferred name.
-
-`uuid` is the identifier of the device the app is running on. This could be used to correlate user accounts over multiple machines.
-
-Any other properties will be discarded.
-
-**Note:** setUser deprecated in 0.4
-
-Release 0.3 previously had a setUser function that accepted a string or function to specify the user, however it did not accept arguments. This method is considered deprecated and will be removed in the 1.0 release, thus it is advised to update your code to set it with the new *user* function.
+This is not recommended, the method has been marked as _deprecated_ and will be eventually removed.
+It is advised to update your code to set it with the `user(request)` method or provide the `userInfo` in the `send()` call.
 
 ### Version tracking
 

--- a/examples/express-sample/package-lock.json
+++ b/examples/express-sample/package-lock.json
@@ -26,9 +26,8 @@
       "dependencies": {
         "@types/express": "^4.17.21",
         "debug": "^4.3.4",
-        "object-to-human-string": "0.0.3",
         "stack-trace": "0.0.10",
-        "uuid": "^9.0.1"
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.2.0",

--- a/examples/express-sample/routes/index.js
+++ b/examples/express-sample/routes/index.js
@@ -43,7 +43,10 @@ router.get("/send", function (req, res, next) {
   };
 
   raygunClient
-    .send("Custom Raygun Error in /send endpoint", { tags: ["request"], userInfo })
+    .send("Custom Raygun Error in /send endpoint", {
+      tags: ["request"],
+      userInfo,
+    })
     .then((message) => {
       res.render("send", {
         title: "Sent custom error to Raygun",

--- a/examples/express-sample/routes/index.js
+++ b/examples/express-sample/routes/index.js
@@ -36,8 +36,14 @@ router.get("/send", function (req, res, next) {
     },
   });
 
+  // Provide custom user info in /send endpoint
+  const userInfo = {
+    identifier: "123456",
+    email: "custom@example.com",
+  };
+
   raygunClient
-    .send("Custom Raygun Error in /send endpoint", { tags: ["request"] })
+    .send("Custom Raygun Error in /send endpoint", { tags: ["request"], userInfo })
     .then((message) => {
       res.render("send", {
         title: "Sent custom error to Raygun",

--- a/lib/raygun.messageBuilder.ts
+++ b/lib/raygun.messageBuilder.ts
@@ -25,13 +25,12 @@ import {
   Environment,
   BuiltError,
   Breadcrumb,
+  UserMessageData,
 } from "./types";
 
 import { humanString } from "./raygun.human";
 
 const debug = require("debug")("raygun");
-
-type UserMessageData = RawUserData | string | undefined;
 
 const packageDetails = require("../package.json");
 
@@ -238,9 +237,12 @@ export class RaygunMessageBuilder {
     return this;
   }
 
-  setUser(user: (() => UserMessageData) | UserMessageData) {
-    let userData: UserMessageData;
+  setUser(user: (() => UserMessageData) | UserMessageData | undefined) {
+    if (!user) {
+      return this;
+    }
 
+    let userData: UserMessageData;
     if (user instanceof Function) {
       userData = user();
     } else {
@@ -265,6 +267,9 @@ export class RaygunMessageBuilder {
     const data: UserDetails = {};
     if (userData.identifier) {
       data.identifier = userData.identifier;
+    } else {
+      // Mark user as Anonymous if no identifier is provided
+      data.isAnonymous = true;
     }
     if (userData.email) {
       data.email = userData.email;

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -241,11 +241,12 @@ class Raygun {
    * @param request custom RequestParams.
    * @param tags to attach to the error report.
    * @param timestamp to provide a custom timestamp as Date object or number in milliseconds since epoch.
+   * @param userInfo to provide the user information to this error report. Has priority over the user(request) method.
    * @return IncomingMessage if message was delivered, null if stored, rejected with Error if failed.
    */
   async send(
     exception: Error | string,
-    { customData, request, tags, timestamp }: SendParameters = {},
+    { customData, request, tags, timestamp, userInfo }: SendParameters = {},
   ): Promise<IncomingMessage | null> {
     // Convert timestamp in milliseconds since epoch to Date
     const _timestamp =
@@ -257,6 +258,7 @@ class Raygun {
       request,
       tags,
       _timestamp,
+      userInfo,
     );
 
     const message = sendOptionsResult.message;
@@ -491,6 +493,7 @@ class Raygun {
     request?: RequestParams,
     tags?: Tag[],
     timestamp?: Date,
+    userInfo?: RawUserData,
   ): SendOptionsResult {
     let mergedTags: Tag[] = [];
     let skip = false;
@@ -515,7 +518,7 @@ class Raygun {
       .setMachineName()
       .setEnvironmentDetails()
       .setUserCustomData(customData)
-      .setUser(this.user(request) || this._user)
+      .setUser(userInfo || this.user(request) || this._user)
       .setVersion(this._version)
       .setBreadcrumbs(breadcrumbs.getBreadcrumbs())
       .setTags(mergedTags);

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -155,12 +155,19 @@ class Raygun {
     return this;
   }
 
+  /**
+   * Override this method to provide user data from the send() method original request parameters.
+   * @param req as RequestParams, may be null if send() was called without providing request parameters.
+   */
   user(req?: RequestParams): RawUserData | null {
     return null;
   }
 
-  // This function is deprecated, is provided for legacy apps and will be
-  // removed in 1.0: use raygun.user instead
+  /**
+   * Sets a user globally.
+   * @deprecated Implement user(request) callback or provide userInfo in send() method call instead
+   * @param user as RawUserData
+   */
   setUser(user: RawUserData) {
     this._user = user;
     return this;

--- a/lib/raygun.ts
+++ b/lib/raygun.ts
@@ -18,13 +18,13 @@ import {
   MessageTransport,
   IOfflineStorage,
   OfflineStorageOptions,
-  RawUserData,
   RaygunOptions,
   RequestParams,
   SendOptions,
   Tag,
   Transport,
   SendParameters,
+  UserMessageData,
 } from "./types";
 import * as breadcrumbs from "./raygun.breadcrumbs";
 import { addRequestBreadcrumb } from "./raygun.breadcrumbs.express";
@@ -71,7 +71,7 @@ class Raygun {
 
   _filters: string[] = [];
 
-  _user: RawUserData | undefined;
+  _user: UserMessageData | undefined;
 
   _version: string = "";
 
@@ -159,7 +159,7 @@ class Raygun {
    * Override this method to provide user data from the send() method original request parameters.
    * @param req as RequestParams, may be null if send() was called without providing request parameters.
    */
-  user(req?: RequestParams): RawUserData | null {
+  user(req?: RequestParams): UserMessageData | null {
     return null;
   }
 
@@ -168,7 +168,7 @@ class Raygun {
    * @deprecated Implement user(request) callback or provide userInfo in send() method call instead
    * @param user as RawUserData
    */
-  setUser(user: RawUserData) {
+  setUser(user: UserMessageData) {
     this._user = user;
     return this;
   }
@@ -493,7 +493,7 @@ class Raygun {
     request?: RequestParams,
     tags?: Tag[],
     timestamp?: Date,
-    userInfo?: RawUserData,
+    userInfo?: UserMessageData,
   ): SendOptionsResult {
     let mergedTags: Tag[] = [];
     let skip = false;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -226,4 +226,5 @@ export interface SendParameters {
   request?: RequestParams;
   tags?: Tag[];
   timestamp?: Date | number;
+  userInfo?: RawUserData;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -107,21 +107,38 @@ export type RequestDetails = {
 };
 
 export type UserDetails = {
+  // Unique identifier for the user
   identifier?: string;
-  uuid?: string;
+  // Flag indicating if the user is anonymous or not
+  // Users should not be modifying this member manually
+  isAnonymous?: boolean;
+  // User's first name (what you would use if you were emailing them - "Hi {{firstName}}, ...")
   firstName?: string;
-  lastName?: string;
+  // User's full name
   fullName?: string;
+  // User's email address
   email?: string;
+  // Device unique identifier. Useful if sending errors from a mobile device.
+  uuid?: string;
 };
 
+/**
+ * Either a string identifier or a RawUserData object
+ * Supports legacy clients providing identifier directly
+ */
+export type UserMessageData = RawUserData | string;
+
 export type RawUserData = {
+  // Unique identifier for the user
   identifier?: string;
-  uuid?: string;
+  // User's first name (what you would use if you were emailing them - "Hi {{firstName}}, ...")
   firstName?: string;
-  lastName?: string;
+  // User's full name
   fullName?: string;
+  // User's email address
   email?: string;
+  // Device unique identifier. Useful if sending errors from a mobile device.
+  uuid?: string;
 };
 
 export type OfflineStorageOptions = {
@@ -226,5 +243,5 @@ export interface SendParameters {
   request?: RequestParams;
   tags?: Tag[];
   timestamp?: Date | number;
-  userInfo?: RawUserData;
+  userInfo?: UserMessageData;
 }

--- a/test/raygun_express_test.js
+++ b/test/raygun_express_test.js
@@ -141,6 +141,25 @@ test("user function is called even if request is not present", async function (t
   t.same(message.details.user, { email: "test@null.null" });
 });
 
+test("provide userInfo in send method", async function (t) {
+  t.plan(1);
+
+  const testEnvironment = await makeClientWithMockServer();
+  const raygunClient = testEnvironment.client;
+
+  const userInfo = { email: "test@null.null" };
+
+  const nextRequest = testEnvironment.nextRequest();
+
+  raygunClient.send(new Error("example error"), { userInfo });
+
+  const message = await nextRequest;
+
+  testEnvironment.stop();
+
+  t.same(message.details.user, { email: "test@null.null" });
+});
+
 test("string exceptions are sent intact", async function (t) {
   t.plan(1);
 

--- a/test/raygun_express_test.js
+++ b/test/raygun_express_test.js
@@ -128,7 +128,7 @@ test("user function is called even if request is not present", async function (t
   const testEnvironment = await makeClientWithMockServer();
   const raygunClient = testEnvironment.client;
 
-  raygunClient.user = () => ({ email: "test@null.null" });
+  raygunClient.user = () => ({ identifier: "id" });
 
   const nextRequest = testEnvironment.nextRequest();
 
@@ -138,7 +138,7 @@ test("user function is called even if request is not present", async function (t
 
   testEnvironment.stop();
 
-  t.same(message.details.user, { email: "test@null.null" });
+  t.same(message.details.user, { identifier: "id" });
 });
 
 test("provide userInfo in send method", async function (t) {
@@ -147,7 +147,7 @@ test("provide userInfo in send method", async function (t) {
   const testEnvironment = await makeClientWithMockServer();
   const raygunClient = testEnvironment.client;
 
-  const userInfo = { email: "test@null.null" };
+  const userInfo = { identifier: "id" };
 
   const nextRequest = testEnvironment.nextRequest();
 
@@ -157,7 +157,7 @@ test("provide userInfo in send method", async function (t) {
 
   testEnvironment.stop();
 
-  t.same(message.details.user, { email: "test@null.null" });
+  t.same(message.details.user, { identifier: "id" });
 });
 
 test("string exceptions are sent intact", async function (t) {


### PR DESCRIPTION
## feat: #218 Optional `userInfo` in `send()`

### Description :memo:
- **Purpose**: Improve how users can provide user information to their error reports
- **Approach**: 

Users have previously complained that the current implementation, based on the request, cannot be used in all situations. (see comments in #218).

The other older way, was to call to a global `setUser(user)` method, but that will cause problems when handling multiple requests by the same client, as not all requests are linked to the same user.

To fix that, I take inspiration on how the `raygun4net` package does it: https://github.com/MindscapeHQ/raygun4net/blob/ff5ef7eb6a3adaa7fdd49f2cd835fe8e68aef63d/Mindscape.Raygun4Net4/RaygunClient.cs#L339

By allowing users to pass the user information in the `send()` method, they can customize the way they provide the user information and ensure that the correct user information is attached to the error report.

e.g.

```js
client.send(new Error(), { userInfo });
```

This user information will take priority over the currently existing methods.

But, at the same time, the raygun client still works as before, so users don't need to change their code.

- Closes: #218 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**Updates**

- Add optional `userInfo` parameter to `send()`.
- Pass user information to the internal message builder.
- Add tests.

### Test plan :test_tube:

- Unit test implemented.
- Implemented custom userInfo in express example:

Example, adding this user information:

```js
// Provide custom user info in /send endpoint
  const userInfo = {
    identifier: "123456",
    email: "custom@example.com",
  };

  raygunClient
    .send("Custom Raygun Error in /send endpoint", { tags: ["request"], userInfo })
```

Gets reported as:

![image](https://github.com/MindscapeHQ/raygun4node/assets/2494376/8df24701-2c6a-4526-b490-e4e4fcba7f82)

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [x] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)