### PR TITLE
chore: #224 add clarification on sourcemaps and breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ Including column numbers can enable source mapping if you have minified or trans
 Raygun supports source mapping for Node.js stacktraces which include column numbers. To enable this feature you will need to upload your map files to the JavaScript Source Map Center and enable the processing of Node.js error stacktraces.
 
 ##### Using Private Source Maps with Node.js apps
+
 Raygun supports source mapping for Node.js stacktraces which include column numbers. To enable this feature simply upload your map files as per the instructions on this page and enable the processing of Node.js errors with this setting in Raygun.
 
 ### Node.js source maps
@@ -572,6 +573,7 @@ All requests use the same authentication methods as the upload call (Basic Authe
 ### Known Issues
 
 - Node will show compilation warnings when using Raygun4Node in Webpack applications.
+- Although Breadcrumbs report the source filename, code line and function name, these are not processed using source maps like with stack traces.
 
 ### Examples
 View a screencast on creating an app with Node.js and Express.js, then hooking up the error handling and sending them at [https://raygun.com/blog/2013/07/video-nodejs-error-handling-with-raygun/](https://raygun.com/blog/2013/07/video-nodejs-error-handling-with-raygun/)

--- a/lib/raygun.breadcrumbs.ts
+++ b/lib/raygun.breadcrumbs.ts
@@ -88,8 +88,6 @@ export function addBreadcrumb(
     type,
     className: callsite?.fileName,
     methodName: callsite?.functionName,
-
-    // TODO - do we need to do any source mapping?
     lineNumber: callsite?.lineNumber || undefined,
   };
 


### PR DESCRIPTION
## chore: #224 add clarification on sourcemaps and breadcrumbs

### Description :memo:
- **Purpose**: Resolve question raised in #224 
- **Approach**: Checked how source map processing works on Raygun and checked if Breadcrumbs can be also processed.

**Type of change**

- [x] Chore

**Updates**

Checked with the team, Raygun docs and setup proper source mapping in a sample project.

Then I verified that Raygun doesn't process Breadcrumb attached source lines like with stacktraces. As well, the API is missing the actual filename and the column number, which are necessary by the source maps.

- Removed TODO
- Added clarification in README

### Test plan :test_tube:

- None, just code cleanup.

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)