### PR TITLE
chore: Prepare changelogs and version bump 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,20 @@
 
 TODO: Add the missing PRs here once merged!
 
-- feat: #65 Custom timestamp parameter (#254) (2024-06-19)
-- fix: #68 Better humanize string functionality (#255) (2024-06-20)
-- doc: #196 add documentation on handling errors in sync transport (#259) (2024-06-19)
-- refactor: #199 batch callbacks (#261) (2024-06-24)
-- chore: #224 add clarification on sourcemaps and breadcrumbs (#270) (2024-06-26)
-- chore(deps-dev): bump @types/node from 20.14.2 to 20.14.8 (#268) (2024-06-24)
-- chore(deps-dev): bump @types/uuid from 9.0.8 to 10.0.0 (#267) (2024-06-24)
-- chore(deps-dev): bump @stylistic/eslint-plugin from 2.1.0 to 2.2.2 (#265) (2024-06-24)
-- chore(deps-dev): bump typescript-eslint from 7.13.0 to 7.13.1 (#264) (2024-06-24)
-- chore(deps-dev): bump typescript-eslint from 7.11.0 to 7.13.0 (#258) (2024-06-18)
-- chore(deps-dev): bump prettier from 3.3.0 to 3.3.2 (#257) (2024-06-18)
-- chore(deps-dev): bump tap from 19.0.2 to 19.2.5 (#256) (2024-06-18)
-- chore(deps): bump uuid from 9.0.1 to 10.0.0 (#250) (2024-06-18)
-- chore(deps-dev): bump @types/node from 20.14.0 to 20.14.2 (#247) (2024-06-18)
+- feat: #65 Custom timestamp parameter (#254)
+- fix: #68 Better humanize string functionality (#255)
+- doc: #196 add documentation on handling errors in sync transport (#259)
+- refactor: #199 batch callbacks (#261)
+- chore: #224 add clarification on sourcemaps and breadcrumbs (#270)
+- chore(deps-dev): bump @types/node from 20.14.2 to 20.14.8 (#268)
+- chore(deps-dev): bump @types/uuid from 9.0.8 to 10.0.0 (#267)
+- chore(deps-dev): bump @stylistic/eslint-plugin from 2.1.0 to 2.2.2 (#265)
+- chore(deps-dev): bump typescript-eslint from 7.13.0 to 7.13.1 (#264)
+- chore(deps-dev): bump typescript-eslint from 7.11.0 to 7.13.0 (#258)
+- chore(deps-dev): bump prettier from 3.3.0 to 3.3.2 (#257)
+- chore(deps-dev): bump tap from 19.0.2 to 19.2.5 (#256)
+- chore(deps): bump uuid from 9.0.1 to 10.0.0 (#250)
+- chore(deps-dev): bump @types/node from 20.14.0 to 20.14.2 (#247)
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 1.2.0
+
+TODO: Add the missing PRs here once merged!
+
+- feat: #65 Custom timestamp parameter (#254) (2024-06-19)
+- fix: #68 Better humanize string functionality (#255) (2024-06-20)
+- doc: #196 add documentation on handling errors in sync transport (#259) (2024-06-19)
+- refactor: #199 batch callbacks (#261) (2024-06-24)
+- chore: #224 add clarification on sourcemaps and breadcrumbs (#270) (2024-06-26)
+- chore(deps-dev): bump @types/node from 20.14.2 to 20.14.8 (#268) (2024-06-24)
+- chore(deps-dev): bump @types/uuid from 9.0.8 to 10.0.0 (#267) (2024-06-24)
+- chore(deps-dev): bump @stylistic/eslint-plugin from 2.1.0 to 2.2.2 (#265) (2024-06-24)
+- chore(deps-dev): bump typescript-eslint from 7.13.0 to 7.13.1 (#264) (2024-06-24)
+- chore(deps-dev): bump typescript-eslint from 7.11.0 to 7.13.0 (#258) (2024-06-18)
+- chore(deps-dev): bump prettier from 3.3.0 to 3.3.2 (#257) (2024-06-18)
+- chore(deps-dev): bump tap from 19.0.2 to 19.2.5 (#256) (2024-06-18)
+- chore(deps): bump uuid from 9.0.1 to 10.0.0 (#250) (2024-06-18)
+- chore(deps-dev): bump @types/node from 20.14.0 to 20.14.2 (#247) (2024-06-18)
+
 ## 1.1.0
 
 - feat: Part of #220 add internal runWithBreadcrumbsAsync function (#245) (2024-06-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 1.2.0
 
-TODO: Add the missing PRs here once merged!
-
+- feat: #218 Optional `userInfo` in `send()`
 - feat: #65 Custom timestamp parameter (#254)
 - fix: #68 Better humanize string functionality (#255)
 - doc: #196 add documentation on handling errors in sync transport (#259)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raygun",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raygun",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@types/express": "^4.17.21",
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun package for Node.js, written in TypeScript",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "Raygun",


### PR DESCRIPTION
## chore: Prepare changelogs and version bump 1.2.0

### Description :memo:

- **Purpose**: Changelog and version bump on `package.json`
- **Approach**: Update changelog and increase minor version.
- Depends on https://github.com/MindscapeHQ/raygun4node/pull/269
- Depends on https://github.com/MindscapeHQ/raygun4node/pull/263

**Type of change**

- [x] Chore

**Updates**

- Updated CHANGELOG
- Update `package.json`
- Update `package-lock.json` through the `npm install`

### Test plan :test_tube:

Run `npm publish --dry-run`

```
 npm publish --dry-run

> raygun@1.2.0 prepare
> tsc

npm notice
npm notice 📦  raygun@1.2.0
npm notice Tarball Contents
npm notice 6.4kB CHANGELOG.md
npm notice 21.4kB README.md
npm notice 0B build/.gitkeep
npm notice 1.3kB build/raygun.batch.d.ts
npm notice 5.5kB build/raygun.batch.js
npm notice 470B build/raygun.breadcrumbs.d.ts
npm notice 204B build/raygun.breadcrumbs.express.d.ts
npm notice 942B build/raygun.breadcrumbs.express.js
npm notice 4.2kB build/raygun.breadcrumbs.js
npm notice 4.4kB build/raygun.d.ts
npm notice 610B build/raygun.human.d.ts
npm notice 1.7kB build/raygun.human.js
npm notice 22.2kB build/raygun.js
npm notice 900B build/raygun.messageBuilder.d.ts
npm notice 9.1kB build/raygun.messageBuilder.js
npm notice 657B build/raygun.offline.d.ts
npm notice 3.7kB build/raygun.offline.js
npm notice 257B build/raygun.sync.transport.d.ts
npm notice 1.3kB build/raygun.sync.transport.js
npm notice 11B build/raygun.sync.worker.d.ts
npm notice 1.7kB build/raygun.sync.worker.js
npm notice 522B build/raygun.transport.d.ts
npm notice 2.4kB build/raygun.transport.js
npm notice 52B build/timer.d.ts
npm notice 408B build/timer.js
npm notice 4.9kB build/types.d.ts
npm notice 509B build/types.js
npm notice 2.1kB package.json
npm notice Tarball Details
npm notice name: raygun
npm notice version: 1.2.0
npm notice filename: raygun-1.2.0.tgz
npm notice package size: 26.5 kB
npm notice unpacked size: 97.9 kB
npm notice shasum: 30c0c2805121496c7d44ed051ff542ec0331e7f8
npm notice integrity: sha512-f09Y5IEqAuJoU[...]bKW6R7ZrPWhkw==
npm notice total files: 28
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ raygun@1.2.0
```

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [x] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)