### PR TITLE
fix: #273 enable isAnonymous parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,13 @@ The following properties can be provided as user information:
 
 - `identifier`: Unique identifier for the user is the user identifier.
 - `email`: User's email address.
+- `isAnonymous`: Flag indicating if the user is anonymous or not.
 - `firstName`: User's first name (what you would use if you were emailing them - "Hi {{firstName}}, ...")
 - `fullName`: User's full name.
 - `uuid`: Device unique identifier. Useful if sending errors from a mobile device.
 
-All properties are `strings`. Any other properties will be discarded.
+All properties are `strings` except `isAnonymous`, which is a boolean.
+As well, they are all optional. Any other properties will be discarded.
 
 Example:
 
@@ -251,6 +253,7 @@ Example:
 userInfo = {
     identifier: "123",
     email: "user@example.com",
+    isAnonymous: false,
     firstName: "First name",
     fullName: "Fullname",
     uuid: "a25dfe58-8db3-496c-8768-375595139375",
@@ -287,6 +290,7 @@ raygunClient.user = function (req) {
     return {
       identifier: req.user.username,
       email: req.user.email,
+      isAnonymous: false,
       fullName: req.user.fullName,
       firstName: req.user.firstName,
       uuid: req.user.deviceID

--- a/lib/raygun.messageBuilder.ts
+++ b/lib/raygun.messageBuilder.ts
@@ -267,9 +267,9 @@ export class RaygunMessageBuilder {
     const data: UserDetails = {};
     if (userData.identifier) {
       data.identifier = userData.identifier;
-    } else {
-      // Mark user as Anonymous if no identifier is provided
-      data.isAnonymous = true;
+    }
+    if (userData.isAnonymous) {
+      data.isAnonymous = userData.isAnonymous;
     }
     if (userData.email) {
       data.email = userData.email;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -106,11 +106,11 @@ export type RequestDetails = {
   form: object;
 };
 
+// Internal type to attach to crash reports
 export type UserDetails = {
   // Unique identifier for the user
   identifier?: string;
   // Flag indicating if the user is anonymous or not
-  // Users should not be modifying this member manually
   isAnonymous?: boolean;
   // User's first name (what you would use if you were emailing them - "Hi {{firstName}}, ...")
   firstName?: string;
@@ -131,6 +131,8 @@ export type UserMessageData = RawUserData | string;
 export type RawUserData = {
   // Unique identifier for the user
   identifier?: string;
+  // Flag indicating if the user is anonymous or not
+  isAnonymous?: boolean;
   // User's first name (what you would use if you were emailing them - "Hi {{firstName}}, ...")
   firstName?: string;
   // User's full name

--- a/test/raygun.messageBuilder_test.js
+++ b/test/raygun.messageBuilder_test.js
@@ -365,12 +365,14 @@ test("user and version builder tests", function (t) {
       return {
         identifier: "testuser",
         email: "test@example.com",
+        isAnonymous: true,
         notSupportedProp: "ignore",
       };
     });
     var message = builder.build();
     tt.equal(message.details.user.identifier, "testuser");
     tt.equal(message.details.user.email, "test@example.com");
+    tt.equal(message.details.user.isAnonymous, true);
     tt.equal(message.details.user.notSupportedProp, undefined);
     tt.end();
   });


### PR DESCRIPTION
## fix: #273 enable isAnonymous parameter

### Description :memo:
- **Purpose**: Enables `isAnonymous` param in User Info payload
- **Approach**: 

As discussed internally, developers using this package should be able to set the `isAnonymous` parameter independently if another parameter is set.

For that, I added the `isAnonymours` property to `RawUserData` and the required logic for it.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Added property
- Modified message builder logic
- Updated tests

### Test plan :test_tube:

- Updated tests
- Tested on express-example

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)