### PR TITLE
chore: Prepare release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2.0.0
+
+- refactor!: #262 remove deprecated methods (#288)
+- fix: #273 enable isAnonymous parameter (#284)
+- docs: #161 Document methods using tsdoc format (#274)
+- chore(deps): bump config in /examples/express-sample (#276)
+- chore(deps): bump config in /examples/using-domains (#282)
+- chore(deps-dev): bump @eslint/js from 9.4.0 to 9.6.0 (#279)
+- chore(deps-dev): bump @stylistic/eslint-plugin from 2.2.2 to 2.3.0 (#286)
+- chore(deps-dev): bump @stylistic/eslint-plugin-ts from 2.2.2 to 2.3.0 (#280)
+- chore(deps-dev): bump @types/node from 20.14.8 to 20.14.9 (#278)
+- chore(deps-dev): bump @types/node from 20.14.9 to 20.14.10 (#285)
+- chore(deps-dev): bump tap from 19.2.5 to 20.0.3 (#277)
+- chore(deps-dev): bump typescript from 5.5.2 to 5.5.3 (#287)
+- chore(deps-dev): bump typescript-eslint from 7.13.1 to 7.15.0 (#283)
+
+**BREAKING CHANGE**
+
+- Removed deprecated methods `setUser()` and `sendWithCallback()`
+
 ## 1.2.0
 
 - feat: #218 Optional `userInfo` in `send()`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raygun",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raygun",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "dependencies": {
         "@types/express": "^4.17.21",
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun package for Node.js, written in TypeScript",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "Raygun",


### PR DESCRIPTION
## chore: Prepare release 2.0.0

### Description :memo:
- **Purpose**: Prepare release 2.0.0
- **Approach**: Update changelog and package files

**Type of change**

- [x] Chore

**Updates**

- Update `CHANGELOG.md`
- Update `package.json`
- Perform `npm install` to update `package-lock.json`

### Test plan :test_tube:

dry run

```
npm publish --dry-run

> raygun@2.0.0 prepare
> tsc

npm notice
npm notice 📦  raygun@2.0.0
npm notice Tarball Contents
npm notice 7.2kB CHANGELOG.md
npm notice 21.2kB README.md
npm notice 0B build/.gitkeep
npm notice 1.3kB build/raygun.batch.d.ts
npm notice 5.6kB build/raygun.batch.js
npm notice 1.1kB build/raygun.breadcrumbs.d.ts
npm notice 231B build/raygun.breadcrumbs.express.d.ts
npm notice 930B build/raygun.breadcrumbs.express.js
npm notice 4.7kB build/raygun.breadcrumbs.js
npm notice 5.8kB build/raygun.d.ts
npm notice 645B build/raygun.human.d.ts
npm notice 1.7kB build/raygun.human.js
npm notice 22.9kB build/raygun.js
npm notice 1.7kB build/raygun.messageBuilder.d.ts
npm notice 10.5kB build/raygun.messageBuilder.js
npm notice 626B build/raygun.offline.d.ts
npm notice 3.7kB build/raygun.offline.js
npm notice 272B build/raygun.sync.transport.d.ts
npm notice 1.3kB build/raygun.sync.transport.js
npm notice 11B build/raygun.sync.worker.d.ts
npm notice 1.7kB build/raygun.sync.worker.js
npm notice 496B build/raygun.transport.d.ts
npm notice 2.4kB build/raygun.transport.js
npm notice 52B build/timer.d.ts
npm notice 379B build/timer.js
npm notice 4.6kB build/types.d.ts
npm notice 77B build/types.js
npm notice 2.1kB package.json
npm notice Tarball Details
npm notice name: raygun
npm notice version: 2.0.0
npm notice filename: raygun-2.0.0.tgz
npm notice package size: 27.9 kB
npm notice unpacked size: 103.4 kB
npm notice shasum: 0fba0986cc3f5beaed2d2ad3ef18f0fbad1292d1
npm notice integrity: sha512-lX4C6ruyjwR64[...]3GeD418/voUtQ==
npm notice total files: 28
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ raygun@2.0.0
```

### Author to check :eyeglasses:
- [ ] Project and all contained modules builds successfully
- [ ] Self-/dev-tested 
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [x] Project and all contained modules builds successfully
- [x] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)