### PR TITLE
ci: Set dependabot interval to "monthly"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/examples/express-sample"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -27,7 +27,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/examples/using-domains"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -40,7 +40,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## ci: Set dependabot interval to "monthly"

### Description :memo:
- **Purpose**: Set dependabot interval to "monthly"
- **Approach**: Modify `dependabot.yml`

As suggested by @sumitramanga 

See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Modified `dependabot.yml`

### Test plan :test_tube:

- None

### Author to check :eyeglasses:
- [ ] Project and all contained modules builds successfully
- [ ] Self-/dev-tested 
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)