### PR TITLE
chore: Prepare release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0
+## 2.1.1
 
 - docs: Some documentation improvements around online/offline behaviour. (#333) (2024-10-23)
 - chore(deps): bump cross-spawn from 7.0.3 to 7.0.6 in /examples/express-sample (#345) (2024-12-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - chore(deps-dev): bump typescript-eslint from 8.3.0 to 8.12.2 (#339) (2024-11-01)
 - chore(deps-dev): bump @eslint/js from 9.11.1 to 9.13.0 (#337) (2024-11-01)
 - chore(deps-dev): bump typescript from 5.5.4 to 5.6.3 (#336) (2024-11-01)
+- chore: Updated package.json to deal with vuln in express dependency (#352) (2025-01-14)
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2.2.0
+
+- feat: Simplication of HTTPOptions across transport, batch transport and offline. (#332) (2024-10-22)
+- docs: Some documentation improvements around online/offline behaviour. (#333) (2024-10-23)
+- chore(deps): bump cross-spawn from 7.0.3 to 7.0.6 in /examples/express-sample (#345) (2024-12-02)
+- chore(deps): bump debug from 4.3.7 to 4.4.0 (#346) (2025-01-06)
+- chore(deps): bump uuid from 10.0.0 to 11.0.2 (#338) (2024-11-01)
+- chore(deps): bump @types/express from 4.17.21 to 5.0.0 (#335) (2024-11-01)
+- chore(deps-dev): bump typescript from 5.6.3 to 5.7.2 (#349) (2025-01-06)
+- chore(deps-dev): bump typescript-eslint from 8.17.0 to 8.19.0 (#348) (2025-01-06)
+- chore(deps-dev): bump eslint from 9.16.0 to 9.17.0 (#350) (2025-01-06)
+- chore(deps-dev): bump eslint from 9.11.1 to 9.16.0 (#340) (2024-12-03)
+- chore(deps-dev): bump nock from 13.5.5 to 13.5.6 (#341) (2024-12-02)
+- chore(deps-dev): bump prettier from 3.3.3 to 3.4.1 (#342) (2024-12-02)
+- chore(deps-dev): bump @eslint/js from 9.13.0 to 9.16.0 (#343) (2024-12-02)
+- chore(deps-dev): bump @stylistic/eslint-plugin from 2.8.0 to 2.11.0 (#344) (2024-12-02)
+- chore(deps-dev): bump typescript-eslint from 8.3.0 to 8.12.2 (#339) (2024-11-01)
+- chore(deps-dev): bump @eslint/js from 9.11.1 to 9.13.0 (#337) (2024-11-01)
+- chore(deps-dev): bump typescript from 5.5.4 to 5.6.3 (#336) (2024-11-01)
+
 ## 2.1.0
 
 - chore(deps): bump cookie and express (#329) (2024-10-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 2.2.0
 
-- feat: Simplication of HTTPOptions across transport, batch transport and offline. (#332) (2024-10-22)
 - docs: Some documentation improvements around online/offline behaviour. (#333) (2024-10-23)
 - chore(deps): bump cross-spawn from 7.0.3 to 7.0.6 in /examples/express-sample (#345) (2024-12-02)
 - chore(deps): bump debug from 4.3.7 to 4.4.0 (#346) (2025-01-06)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raygun",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raygun",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "@types/express": "^5.0.0",
         "debug": "^4.3.4",
@@ -3242,10 +3242,11 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3266,7 +3267,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -3281,6 +3282,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -5215,10 +5220,11 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "dev": true
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raygun",
-  "version": "2.2.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raygun",
-      "version": "2.2.0",
+      "version": "2.1.1",
       "dependencies": {
         "@types/express": "^5.0.0",
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun package for Node.js, written in TypeScript",
-  "version": "2.2.0",
+  "version": "2.1.1",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "Raygun",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun package for Node.js, written in TypeScript",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "Raygun",


### PR DESCRIPTION
## chore: Prepare release 2.1.1
### Description :memo:
- **Purpose**: Prepare for release
- **Approach**: Bump minor version (because new feature), update CHANGELOG and run `npm audit fix`

**Type of change**

- [x] prepare release

**Updates**

- See CHANGELOG

### Test plan :test_tube:

`npm publish --dry-run`

<details>
  <summary>Dry run output</summary>

```
➜  raygun4node git:(release-2.2.0) npm publish --dry-run

> raygun@2.2.0 prepare
> tsc

npm notice
npm notice 📦  raygun@2.2.0
npm notice Tarball Contents
npm notice 10.7kB CHANGELOG.md
npm notice 22.7kB README.md
npm notice 0B build/.gitkeep
npm notice 1.3kB build/raygun.batch.d.ts
npm notice 5.6kB build/raygun.batch.js
npm notice 1.1kB build/raygun.breadcrumbs.d.ts
npm notice 231B build/raygun.breadcrumbs.express.d.ts
npm notice 960B build/raygun.breadcrumbs.express.js
npm notice 4.7kB build/raygun.breadcrumbs.js
npm notice 5.8kB build/raygun.d.ts
npm notice 645B build/raygun.human.d.ts
npm notice 1.7kB build/raygun.human.js
npm notice 24.4kB build/raygun.js
npm notice 1.7kB build/raygun.messageBuilder.d.ts
npm notice 10.5kB build/raygun.messageBuilder.js
npm notice 626B build/raygun.offline.d.ts
npm notice 3.7kB build/raygun.offline.js
npm notice 272B build/raygun.sync.transport.d.ts
npm notice 1.3kB build/raygun.sync.transport.js
npm notice 11B build/raygun.sync.worker.d.ts
npm notice 2.0kB build/raygun.sync.worker.js
npm notice 496B build/raygun.transport.d.ts
npm notice 3.4kB build/raygun.transport.js
npm notice 52B build/timer.d.ts
npm notice 379B build/timer.js
npm notice 4.6kB build/types.d.ts
npm notice 77B build/types.js
npm notice 2.3kB package.json
npm notice Tarball Details
npm notice name: raygun
npm notice version: 2.2.0
npm notice filename: raygun-2.2.0.tgz
npm notice package size: 29.6 kB
npm notice unpacked size: 111.6 kB
npm notice shasum: e332a057c0740bdf1b40e6d6b74fedd2cfec37db
npm notice integrity: sha512-RjiWjlPYQi0wU[...]9Di460ETddpdA==
npm notice total files: 28
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
+ raygun@2.2.0
```

</details>

### Author to check :eyeglasses:

- [ ] Project and all contained modules builds successfully
- [ ] Self-/dev-tested 
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)