### PR TITLE
chore: Updated package.json to deal with vuln in express dependency

### DIFF
--- a/examples/express-sample/package-lock.json
+++ b/examples/express-sample/package-lock.json
@@ -13,7 +13,7 @@
         "cookie-parser": "~1.4.7",
         "debug": "^4.3.4",
         "ejs": "~3.1.10",
-        "express": "^4.19.2",
+        "express": "^4.21.2",
         "morgan": "^1.10.0",
         "node-sass-middleware": "^1.1.0",
         "raygun": "file:../..",
@@ -31,14 +31,14 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.2.0",
-        "@stylistic/eslint-plugin": "^2.0.0",
-        "@stylistic/eslint-plugin-ts": "^2.0.0",
+        "@stylistic/eslint-plugin": "^2.11.0",
+        "@stylistic/eslint-plugin-ts": "^2.11.0",
         "@types/node": "^22.0.2",
         "@types/stack-trace": "0.0.33",
         "@types/uuid": "^10.0.0",
-        "eslint": "^9.11.1",
+        "eslint": "^9.16.0",
         "eslint-plugin-tsdoc": "^0.3.0",
-        "express": "^4.19.2",
+        "express": "^4.21.2",
         "http-terminator": "^3.2.0",
         "jshint": "^2.13.6",
         "nock": "~13",
@@ -47,7 +47,7 @@
         "tap": "^21.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5",
-        "typescript-eslint": "^8.3.0",
+        "typescript-eslint": "^8.17.0",
         "verror": "^1.10.1"
       },
       "engines": {
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -872,7 +872,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -887,6 +887,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/cookie": {
@@ -2202,9 +2206,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",

--- a/examples/express-sample/package.json
+++ b/examples/express-sample/package.json
@@ -11,7 +11,7 @@
     "cookie-parser": "~1.4.7",
     "debug": "^4.3.4",
     "ejs": "~3.1.10",
-    "express": "^4.19.2",
+    "express": "^4.21.2",
     "morgan": "^1.10.0",
     "node-sass-middleware": "^1.1.0",
     "raygun": "file:../..",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/uuid": "^10.0.0",
         "eslint": "^9.16.0",
         "eslint-plugin-tsdoc": "^0.3.0",
-        "express": "^4.19.2",
+        "express": "^4.21.2",
         "http-terminator": "^3.2.0",
         "jshint": "^2.13.6",
         "nock": "~13",
@@ -3242,9 +3242,9 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -3266,7 +3266,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -3281,6 +3281,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -5215,9 +5219,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true
     },
     "node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/uuid": "^10.0.0",
     "eslint": "^9.16.0",
     "eslint-plugin-tsdoc": "^0.3.0",
-    "express": "^4.19.2",
+    "express": "^4.21.2",
     "http-terminator": "^3.2.0",
     "jshint": "^2.13.6",
     "nock": "~13",


### PR DESCRIPTION
Upgraded express from 4.19.2 to 4.21.2

### Description :memo:
- **Purpose**: Dependabot sec report
- **Approach**: updates transitive dependency with the issue

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

:point_right: package.json only
