### PR TITLE
docs: add Releasing and Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to Raygun4Node
+
+## Project and library organisation
+
+Building the project requires [Node.js](https://nodejs.org).
+
+The project should work on all LTS Node versions.
+
+- The `raygun` package is at the repository root.
+- The `examples` folder contains example apps showing the provider capabilities.
+
+## Building and running
+
+The recommended IDE for working on this project is Visual Studio Code.
+
+### Tests
+
+To run tests, run `npm run test` or run all tests from VSCode.
+
+### Code analysis
+
+To check the code, run `npm run eslint` and `npm run tseslint`.
+
+### Formatting
+
+To format the code, run `npm run prettier`.
+
+### Running examples
+
+Instructions on how to run the examples can be found in the `examples` folder.
+
+## How to contribute?
+
+This section is intended for external contributors not part of the Raygun team.
+
+Before you undertake any work, please create a ticket with your proposal,
+so that it can be coordinated with what we're doing.
+
+If you're interested in contributing on a regular basis,
+please get in touch with the Raygun team.
+
+### Fork the repository
+
+Please fork the main repository from https://github.com/MindscapeHQ/raygun4node
+into your own GitHub account.
+
+### Create a new branch
+
+Create a local branch off `develop` in your fork,
+named so that it explains the work in the branch.
+
+Do not submit a PR directly from your `develop` branch.
+
+### Open a pull request
+
+Submit a pull request against the main repositories' `develop` branch. 
+
+Fill the PR template and give it a title that follows the [Conventional Commits guidelines](https://www.conventionalcommits.org/en/v1.0.0/).
+
+### Wait for a review
+
+Wait for a review by the Raygun team.
+The team will leave you feedback and might ask you to do changes in your code.
+
+Once the PR is approved, the team will merge it.
+

--- a/README.md
+++ b/README.md
@@ -624,9 +624,6 @@ View a screencast on creating an app with Node.js and Express.js, then hooking u
 ### Debug Logging
 You can enable logging of debug information from the Raygun client by setting the environment variable `DEBUG=raygun`. The client will then log information about transporting and storing errors, including timing information.
 
-## Contributing
-In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using `npm run test`, `npm run eslint`, `npm run tseslint` and `npm run prettier`.
-
 ## Release History
 
 [View the changelog here](CHANGELOG.md)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,104 @@
+# Releasing Raygun4Node
+
+Raygun for Node is published on npmjs.com as [`raygun`](https://www.npmjs.com/package/raygun).
+
+## Semantic versioning
+
+This package follows semantic versioning.
+
+Given a version number MAJOR.MINOR.PATCH (x.y.z), increment the:
+
+- MAJOR version when you make incompatible changes
+- MINOR version when you add functionality in a backward compatible manner
+- PATCH version when you make backward compatible bug fixes
+
+To learn more about semantic versioning check: https://semver.org/
+
+## Preparing for release
+
+### Release branch
+
+Create a new branch named `release/x.y.z` 
+where `x.y.z` is the Major, Minor and Patch release numbers.
+
+### Update version
+
+Update the `version` in the `package.json` file.
+
+### Run npm install
+
+Run `npm install` to update the version in the `package-lock.json`.
+
+### Update CHANGELOG.md
+
+Add a new entry in the `CHANGELOG.md` file.
+
+Obtain a list of changes using the following git command:
+
+```
+git log --pretty=format:"- %s (%as)"
+```
+
+### Run publish dry-run
+
+Run a publish dry-run to ensure no errors appear:
+
+```
+npm publish --dry-run
+```
+
+### Commit and open a PR
+
+Commit all the changes into a commit with the message `chore: Release x.y.z`
+where `x.y.z` is the Major, Minor and Patch release numbers.
+
+Then push the branch and open a new PR, ask the team to review it.
+
+## Publishing
+
+### PR approval
+
+Once the PR has been approved, you can publish the provider.
+
+### Publish to npmjs.com
+
+Run the publish command without `dry-run`.
+You will need an account in npmjs.com to publish, 
+as well as being part of the [Raygun organization](https://www.npmjs.com/~raygunowner).
+
+```
+npm publish
+```
+
+Now the package is available for customers.
+
+### Merge PR to develop
+
+With the PR approved and the package published, 
+squash and merge the PR into `develop`.
+
+### Tag and create Github Release
+
+Go to https://github.com/MindscapeHQ/raygun4node/releases and create a new Release.
+
+GitHub will create a tag for you, you don't need to create the tag manually.
+
+You can also generate the release notes automatically.
+
+## Merge to `master`
+
+Once the release process is completed, it would be good to merge `develop` into `master`.
+
+### Create a merge PR
+
+Create a PR manually where `develop` merges into `master`
+or by following this link: https://github.com/MindscapeHQ/raygun4node/compare/develop...master
+
+You can name the PR `chore: merge to master`.
+
+Then ask for approval by the Raygun team.
+
+### Merge, don't squash
+
+Do not squash this PR, instead, just merge. That will create a merge commit.
+


### PR DESCRIPTION
## docs: add Releasing and Contributing

### Description :memo:
- **Purpose**: Adds releasing and contributing documents
- **Approach**: Following the same template as Raygun4Flutter

**Type of change**

- Docs

**Updates**

- Created documents.
- Removed section from README.md as it was moved to the Contributing doc.

### Author to check :eyeglasses:
- [ ] Project and all contained modules builds successfully
- [ ] Self-/dev-tested 
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [x] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)