### PR TITLE
fix(sdk): Add host to headers if specified

### DIFF
--- a/lib/raygun.transport.ts
+++ b/lib/raygun.transport.ts
@@ -44,7 +44,7 @@ export function send(
       path: path,
       method: "POST",
       headers: {
-        Host: API_HOST,
+        Host: options.http?.host || API_HOST,
         "Content-Type": "application/json",
         "Content-Length": data.length,
         "X-ApiKey": options.http?.apiKey,


### PR DESCRIPTION
## bug: #372 Support for a proxy using SSL

### Description :memo:
- **Purpose**: Implements a solution for [raygun.transport: Support for a proxy using SSL](https://github.com/MindscapeHQ/raygun4node/issues/372)
- **Approach**: It assigns the host header based on the client options, falling back to the constant in the class.

**Type of change**

*Delete options that are not relevant.*

- [X] Bug fix (non-breaking change which fixes an issue)

**Updates**

:point_right: raygun.transport pulls host header from options.http.host

### Test plan :test_tube:
Follow reproduction steps from [raygun.transport: Support for a proxy using SSL](https://github.com/MindscapeHQ/raygun4node/issues/372)

### Author to check :eyeglasses:
- [X] Project and all contained modules builds successfully
- [X] Self-/dev-tested 
- [X] Unit/UI/Automation/Integration tests provided where applicable
- [X] Code is written to standards
- [X] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)