### PR TITLE
fix: update stale example lockfiles to resolve tar and qs vulnerabilities

### DIFF
--- a/examples/express-sample/package-lock.json
+++ b/examples/express-sample/package-lock.json
@@ -95,7 +95,7 @@
       }
     },
     "../../node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
+      "version": "4.9.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -112,7 +112,7 @@
       }
     },
     "../../node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
+      "version": "4.12.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -798,12 +798,12 @@
       }
     },
     "../../node_modules/@stylistic/eslint-plugin": {
-      "version": "5.6.1",
+      "version": "5.7.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.0",
-        "@typescript-eslint/types": "^8.47.0",
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.53.1",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -1426,7 +1426,7 @@
       "license": "MIT"
     },
     "../../node_modules/@types/node": {
-      "version": "24.10.1",
+      "version": "25.1.0",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1463,18 +1463,18 @@
       "license": "MIT"
     },
     "../../node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.51.0",
-        "@typescript-eslint/type-utils": "8.51.0",
-        "@typescript-eslint/utils": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.54.0",
+        "@typescript-eslint/type-utils": "8.54.0",
+        "@typescript-eslint/utils": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.2.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1484,7 +1484,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.51.0",
+        "@typescript-eslint/parser": "^8.54.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -1498,15 +1498,15 @@
       }
     },
     "../../node_modules/@typescript-eslint/parser": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.51.0",
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.54.0",
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1521,13 +1521,13 @@
       }
     },
     "../../node_modules/@typescript-eslint/project-service": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.51.0",
-        "@typescript-eslint/types": "^8.51.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1541,12 +1541,12 @@
       }
     },
     "../../node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0"
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1557,7 +1557,7 @@
       }
     },
     "../../node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1572,15 +1572,15 @@
       }
     },
     "../../node_modules/@typescript-eslint/type-utils": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0",
-        "@typescript-eslint/utils": "8.51.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.2.0"
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0",
+        "@typescript-eslint/utils": "8.54.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1595,7 +1595,7 @@
       }
     },
     "../../node_modules/@typescript-eslint/types": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1607,19 +1607,19 @@
       }
     },
     "../../node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.51.0",
-        "@typescript-eslint/tsconfig-utils": "8.51.0",
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0",
-        "debug": "^4.3.4",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
+        "@typescript-eslint/project-service": "8.54.0",
+        "@typescript-eslint/tsconfig-utils": "8.54.0",
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.2.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1655,14 +1655,14 @@
       }
     },
     "../../node_modules/@typescript-eslint/utils": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.51.0",
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.54.0",
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1677,11 +1677,11 @@
       }
     },
     "../../node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/types": "8.54.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -4052,11 +4052,11 @@
       }
     },
     "../../node_modules/nock": {
-      "version": "14.0.7",
+      "version": "14.0.10",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mswjs/interceptors": "^0.39.3",
+        "@mswjs/interceptors": "^0.39.5",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
@@ -4498,7 +4498,7 @@
       }
     },
     "../../node_modules/prettier": {
-      "version": "3.7.4",
+      "version": "3.8.1",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4595,7 +4595,7 @@
       }
     },
     "../../node_modules/qs": {
-      "version": "6.14.1",
+      "version": "6.14.2",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5458,7 +5458,7 @@
       }
     },
     "../../node_modules/tar": {
-      "version": "7.5.6",
+      "version": "7.5.9",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5642,7 +5642,7 @@
       }
     },
     "../../node_modules/ts-api-utils": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5797,14 +5797,14 @@
       }
     },
     "../../node_modules/typescript-eslint": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.51.0",
-        "@typescript-eslint/parser": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0",
-        "@typescript-eslint/utils": "8.51.0"
+        "@typescript-eslint/eslint-plugin": "8.54.0",
+        "@typescript-eslint/parser": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0",
+        "@typescript-eslint/utils": "8.54.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6414,8 +6414,6 @@
     },
     "node_modules/ejs": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-4.0.1.tgz",
-      "integrity": "sha512-krvQtxc0btwSm/nvnt1UpnaFDFVJpJ0fdckmALpCgShsr/iGYHTnJiUliZTgmzq/UxTX33TtOQVKaNigMQp/6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "jake": "^10.9.1"

--- a/examples/using-domains/package-lock.json
+++ b/examples/using-domains/package-lock.json
@@ -89,7 +89,7 @@
       }
     },
     "../../node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
+      "version": "4.9.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -106,7 +106,7 @@
       }
     },
     "../../node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
+      "version": "4.12.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -792,12 +792,12 @@
       }
     },
     "../../node_modules/@stylistic/eslint-plugin": {
-      "version": "5.6.1",
+      "version": "5.7.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.0",
-        "@typescript-eslint/types": "^8.47.0",
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.53.1",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -1420,7 +1420,7 @@
       "license": "MIT"
     },
     "../../node_modules/@types/node": {
-      "version": "24.10.1",
+      "version": "25.1.0",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1457,18 +1457,18 @@
       "license": "MIT"
     },
     "../../node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.51.0",
-        "@typescript-eslint/type-utils": "8.51.0",
-        "@typescript-eslint/utils": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.54.0",
+        "@typescript-eslint/type-utils": "8.54.0",
+        "@typescript-eslint/utils": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.2.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1478,7 +1478,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.51.0",
+        "@typescript-eslint/parser": "^8.54.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -1492,15 +1492,15 @@
       }
     },
     "../../node_modules/@typescript-eslint/parser": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.51.0",
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.54.0",
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1515,13 +1515,13 @@
       }
     },
     "../../node_modules/@typescript-eslint/project-service": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.51.0",
-        "@typescript-eslint/types": "^8.51.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1535,12 +1535,12 @@
       }
     },
     "../../node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0"
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1551,7 +1551,7 @@
       }
     },
     "../../node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1566,15 +1566,15 @@
       }
     },
     "../../node_modules/@typescript-eslint/type-utils": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0",
-        "@typescript-eslint/utils": "8.51.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.2.0"
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0",
+        "@typescript-eslint/utils": "8.54.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1589,7 +1589,7 @@
       }
     },
     "../../node_modules/@typescript-eslint/types": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1601,19 +1601,19 @@
       }
     },
     "../../node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.51.0",
-        "@typescript-eslint/tsconfig-utils": "8.51.0",
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/visitor-keys": "8.51.0",
-        "debug": "^4.3.4",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
+        "@typescript-eslint/project-service": "8.54.0",
+        "@typescript-eslint/tsconfig-utils": "8.54.0",
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/visitor-keys": "8.54.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.2.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1649,14 +1649,14 @@
       }
     },
     "../../node_modules/@typescript-eslint/utils": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.51.0",
-        "@typescript-eslint/types": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.54.0",
+        "@typescript-eslint/types": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1671,11 +1671,11 @@
       }
     },
     "../../node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/types": "8.54.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -4046,11 +4046,11 @@
       }
     },
     "../../node_modules/nock": {
-      "version": "14.0.7",
+      "version": "14.0.10",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mswjs/interceptors": "^0.39.3",
+        "@mswjs/interceptors": "^0.39.5",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
@@ -4492,7 +4492,7 @@
       }
     },
     "../../node_modules/prettier": {
-      "version": "3.7.4",
+      "version": "3.8.1",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4589,7 +4589,7 @@
       }
     },
     "../../node_modules/qs": {
-      "version": "6.14.1",
+      "version": "6.14.2",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5452,7 +5452,7 @@
       }
     },
     "../../node_modules/tar": {
-      "version": "7.5.6",
+      "version": "7.5.9",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5636,7 +5636,7 @@
       }
     },
     "../../node_modules/ts-api-utils": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5791,14 +5791,14 @@
       }
     },
     "../../node_modules/typescript-eslint": {
-      "version": "8.51.0",
+      "version": "8.54.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.51.0",
-        "@typescript-eslint/parser": "8.51.0",
-        "@typescript-eslint/typescript-estree": "8.51.0",
-        "@typescript-eslint/utils": "8.51.0"
+        "@typescript-eslint/eslint-plugin": "8.54.0",
+        "@typescript-eslint/parser": "8.54.0",
+        "@typescript-eslint/typescript-estree": "8.54.0",
+        "@typescript-eslint/utils": "8.54.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6215,8 +6215,6 @@
     },
     "node_modules/config": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/config/-/config-4.2.0.tgz",
-      "integrity": "sha512-mk+ugmNm+BWc2YRlwmuJkORUvUyEP6w9cDUKU2sljFLYI4StXjqGDqQTA2wITi8sYaRdC/PGOuktqy7+Y4PApw==",
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.3"


### PR DESCRIPTION
## Summary

Regenerated the example lockfiles (`examples/using-domains/` and `examples/express-sample/`) which were out of sync with the root `node_modules`.

## Vulnerabilities resolved

- **tar** (npm): Arbitrary File Read/Write via Hardlink Target Escape (#126) — updated from 7.5.6 → 7.5.9 (fix requires ≥7.5.8)
- **qs** (npm): arrayLimit bypass in comma parsing allows denial of service (#118) — updated from 6.14.1 → 6.14.2 (fix requires ≥6.14.2)

## Changes

Lockfile-only changes — no source code modifications.