### PR TITLE
fix: update minimatch in example lock files to resolve ReDoS vulnerabilities

### DIFF
--- a/examples/express-sample/package-lock.json
+++ b/examples/express-sample/package-lock.json
@@ -133,7 +133,7 @@
       }
     },
     "../../node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -188,7 +188,7 @@
       }
     },
     "../../node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -294,25 +294,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "../../node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "../../node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "../../node_modules/@isaacs/cliui": {
@@ -1641,11 +1622,11 @@
       }
     },
     "../../node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2692,11 +2673,11 @@
       }
     },
     "../../node_modules/eslint-plugin-tsdoc/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2794,7 +2775,7 @@
       }
     },
     "../../node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3880,17 +3861,36 @@
       }
     },
     "../../node_modules/minimatch": {
-      "version": "10.1.1",
+      "version": "10.2.4",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "../../node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "../../node_modules/minipass": {
@@ -5544,11 +5544,11 @@
       "license": "ISC"
     },
     "../../node_modules/test-exclude/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"

--- a/examples/using-domains/package-lock.json
+++ b/examples/using-domains/package-lock.json
@@ -127,7 +127,7 @@
       }
     },
     "../../node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -182,7 +182,7 @@
       }
     },
     "../../node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -288,25 +288,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "../../node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "../../node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "../../node_modules/@isaacs/cliui": {
@@ -1635,11 +1616,11 @@
       }
     },
     "../../node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2686,11 +2667,11 @@
       }
     },
     "../../node_modules/eslint-plugin-tsdoc/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2788,7 +2769,7 @@
       }
     },
     "../../node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3874,17 +3855,36 @@
       }
     },
     "../../node_modules/minimatch": {
-      "version": "10.1.1",
+      "version": "10.2.4",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "../../node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "../../node_modules/minipass": {
@@ -5538,11 +5538,11 @@
       "license": "ISC"
     },
     "../../node_modules/test-exclude/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"


### PR DESCRIPTION
Regenerated `package-lock.json` for both example projects to pick up patched minimatch versions:\n\n- minimatch 3.1.2 → 3.1.5 (eslint transitive dependencies)\n- minimatch 9.0.5 → 9.0.9 (typescript-eslint transitive dependencies)\n\nResolves dependabot alerts #150, #158, #159 for ReDoS vulnerability in `matchOne()` with multiple non-adjacent GLOBSTAR segments.