### PR TITLE
chore(deps): address dependabot security updates

### DIFF
--- a/examples/express-sample/package-lock.json
+++ b/examples/express-sample/package-lock.json
@@ -28,13 +28,12 @@
         "stack-trace": "0.0.10"
       },
       "devDependencies": {
-        "@eslint/js": "^9.2.0",
-        "@stylistic/eslint-plugin": "^5.1.0",
-        "@stylistic/eslint-plugin-ts": "^4.1.0",
+        "@eslint/js": "^10.0.1",
+        "@stylistic/eslint-plugin": "^5.10.0",
         "@types/node": "^25.1.0",
         "@types/stack-trace": "0.0.33",
-        "eslint": "^9.16.0",
-        "eslint-plugin-tsdoc": "^0.5.0",
+        "eslint": "^10.1.0",
+        "eslint-plugin-tsdoc": "^0.5.2",
         "express": "^5.1.0",
         "http-terminator": "^3.2.0",
         "nock": "~14",
@@ -43,7 +42,7 @@
         "tap": "^21.5.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.39.0",
+        "typescript-eslint": "^8.58.0",
         "verror": "^1.10.1"
       },
       "engines": {
@@ -771,33 +770,6 @@
       },
       "peerDependencies": {
         "eslint": ">=9.0.0"
-      }
-    },
-    "../../node_modules/@stylistic/eslint-plugin-ts": {
-      "version": "4.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/utils": "^8.32.1",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=9.0.0"
-      }
-    },
-    "../../node_modules/@stylistic/eslint-plugin-ts/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "../../node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
@@ -6246,9 +6218,9 @@
       "license": "MIT"
     },
     "node_modules/ejs": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
-      "integrity": "sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.2.tgz",
+      "integrity": "sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw==",
       "license": "Apache-2.0",
       "bin": {
         "ejs": "bin/cli.js"
@@ -6717,7 +6689,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {

--- a/examples/using-domains/package-lock.json
+++ b/examples/using-domains/package-lock.json
@@ -15,20 +15,19 @@
     },
     "../..": {
       "name": "raygun",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "dependencies": {
         "@types/express": "^5.0.0",
         "debug": "^4.3.4",
         "stack-trace": "0.0.10"
       },
       "devDependencies": {
-        "@eslint/js": "^9.2.0",
-        "@stylistic/eslint-plugin": "^5.1.0",
-        "@stylistic/eslint-plugin-ts": "^4.1.0",
+        "@eslint/js": "^10.0.1",
+        "@stylistic/eslint-plugin": "^5.10.0",
         "@types/node": "^25.1.0",
         "@types/stack-trace": "0.0.33",
-        "eslint": "^9.16.0",
-        "eslint-plugin-tsdoc": "^0.5.0",
+        "eslint": "^10.1.0",
+        "eslint-plugin-tsdoc": "^0.5.2",
         "express": "^5.1.0",
         "http-terminator": "^3.2.0",
         "nock": "~14",
@@ -37,7 +36,7 @@
         "tap": "^21.5.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.39.0",
+        "typescript-eslint": "^8.58.0",
         "verror": "^1.10.1"
       },
       "engines": {
@@ -767,33 +766,6 @@
         "eslint": ">=9.0.0"
       }
     },
-    "../../node_modules/@stylistic/eslint-plugin-ts": {
-      "version": "4.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/utils": "^8.32.1",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=9.0.0"
-      }
-    },
-    "../../node_modules/@stylistic/eslint-plugin-ts/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "../../node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "dev": true,
@@ -803,17 +775,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "../../node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "../../node_modules/@tapjs/after": {
@@ -2904,9 +2865,9 @@
       }
     },
     "../../node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -2975,7 +2936,9 @@
       }
     },
     "../../node_modules/flatted": {
-      "version": "3.3.1",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3400,7 +3363,9 @@
       }
     },
     "../../node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4365,6 +4330,19 @@
         "node": ">=16"
       }
     },
+    "../../node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "../../node_modules/pirates": {
       "version": "4.0.7",
       "dev": true,
@@ -5309,7 +5287,9 @@
       }
     },
     "../../node_modules/tar": {
-      "version": "7.5.9",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5452,17 +5432,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "../../node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "../../node_modules/toidentifier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3458,9 +3458,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -4069,9 +4069,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- Updates vulnerable dev transitive dependencies in the root lockfile:
  - `fast-uri` 3.1.0 -> 3.1.2
  - `ip-address` 10.1.0 -> 10.2.0
- Refreshes stale `examples/using-domains` lockfile entries for Dependabot security alerts.
- Updates Express sample runtime dependencies:
  - `ejs` 5.0.1 -> 5.0.2
  - `path-to-regexp` 0.1.12 -> 0.1.13

## Verification

- `npm audit --omit=dev`
- `npm audit --omit=dev` in `examples/using-domains`
- `npm audit --omit=dev` in `examples/express-sample`
- `npm test`
- `npm run test:cjs`
- `npm run prepare`