### PR TITLE
chore: Release 2.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.2.6
+
+- chore(deps-dev): bump tar from 7.5.9 to 7.5.10 (#480) (2026-03-07)
+- chore(deps-dev): bump tar from 7.5.10 to 7.5.11 (#481) (2026-03-12)
+- chore(deps-dev): bump flatted from 3.3.3 to 3.4.2 (#482) (2026-03-24)
+- chore(deps): bump picomatch from 4.0.3 to 4.0.4 (#483) (2026-03-26)
+- chore(deps): bump marocchino/sticky-pull-request-comment from 2 to 3 (#488) (2026-04-01)
+- chore(deps-dev): bump @types/node from 25.3.3 to 25.5.0 (#485) (2026-04-01)
+- chore(deps): bump ejs from 4.0.1 to 5.0.1 in /examples/express-sample (#489) (2026-04-02)
+- chore(deps-dev): bump @stylistic/eslint-plugin from 5.9.0 to 5.10.0 (#486) (2026-04-02)
+- chore(deps-dev): bump typescript-eslint from 8.56.1 to 8.58.0 (#484) (2026-04-02)
+- chore: upgrade to ESLint 10 and unify stylistic plugins (#490) (2026-04-02)
+- chore(deps): address Dependabot security updates (#499) (2026-05-11)
+- chore(deps-dev): update dev tooling dependencies (#500) (2026-05-11)
+- chore(deps-dev): bump TypeScript from 5.9.3 to 6.0.3 (#495) (2026-05-11)
+
 ## 2.2.5
 
 - fix: update stale example lockfiles to resolve tar vulnerability (CVE in tar <7.5.8) (#468) (2026-02-22)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raygun",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raygun",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "dependencies": {
         "@types/express": "^5.0.0",
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun package for Node.js, written in TypeScript",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "Raygun",


### PR DESCRIPTION
## chore: Release 2.2.6

### Description :memo:
- **Purpose**: Prepare release 2.2.6 with dependency maintenance, security cleanup, and TypeScript 6 compiler support.
- **Approach**: Bump version in `package.json`/`package-lock.json` and update `CHANGELOG.md` with all changes since 2.2.5.

**Type of change**

- [x] Bug fix / maintenance release (non-breaking dependency and security maintenance)

**Updates**

:point_right: Version bump from 2.2.5 to 2.2.6
:point_right: Updated `CHANGELOG.md` with all changes since 2.2.5
:point_right: Includes Dependabot/security cleanup from PRs #499 and #500
:point_right: Includes TypeScript 6 dev compiler update from PR #495

### Changes since 2.2.5

- chore(deps-dev): bump tar from 7.5.9 to 7.5.10 (#480)
- chore(deps-dev): bump tar from 7.5.10 to 7.5.11 (#481)
- chore(deps-dev): bump flatted from 3.3.3 to 3.4.2 (#482)
- chore(deps): bump picomatch from 4.0.3 to 4.0.4 (#483)
- chore(deps): bump marocchino/sticky-pull-request-comment from 2 to 3 (#488)
- chore(deps-dev): bump @types/node from 25.3.3 to 25.5.0 (#485)
- chore(deps): bump ejs from 4.0.1 to 5.0.1 in /examples/express-sample (#489)
- chore(deps-dev): bump @stylistic/eslint-plugin from 5.9.0 to 5.10.0 (#486)
- chore(deps-dev): bump typescript-eslint from 8.56.1 to 8.58.0 (#484)
- chore: upgrade to ESLint 10 and unify stylistic plugins (#490)
- chore(deps): address Dependabot security updates (#499)
- chore(deps-dev): update dev tooling dependencies (#500)
- chore(deps-dev): bump TypeScript from 5.9.3 to 6.0.3 (#495)

### Test plan :test_tube:
- `npm test` — all 258 tests pass
- `npm run eslint` / `npm run tseslint` — clean after autofix, with release branch left containing only release metadata changes
- `npm run test:cjs` — CommonJS compatibility passes
- `npm audit` — 0 vulnerabilities at root
- `npm audit --omit=dev` — 0 vulnerabilities in both examples
- `npm pack --dry-run` — clean, package contents generated for 2.2.6
- `npx prettier --check lib/*.ts test/*.js examples/**/*.js` — clean

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)