### PR TITLE
chore(ci): make prettier check deterministic

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -35,26 +35,17 @@ jobs:
     # Run static analysis on TS files
     - run: npm run tseslint
 
-  # Checks code formatting, fails if there are changes after applying prettier.
-  # Based on this example here:
-  # https://github.com/creyD/prettier_action?tab=readme-ov-file#example-4-dry-run
+  # Checks code formatting using the version pinned in package-lock.json.
   prettier:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
         with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
-          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
-          persist-credentials: false
-
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.6
-        with:
-          # "dry" causes that if any file is modified, the job fails
-          dry: True
-          # "write" performs changes in place
-          prettier_options: --write lib/*.ts test/*.js examples/**/*.js
-          github_token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          node-version: 24.x
+          cache: 'npm'
+      - run: npm ci
+      - run: npm exec -- prettier --check "lib/*.ts" "test/*.js" "examples/**/*.js"


### PR DESCRIPTION
## Summary

- run the formatting check with the Prettier version pinned in `package-lock.json`
- replace the write-and-diff third-party action with Prettier's native `--check` mode
- remove the unnecessary personal access token from the formatting job

## Motivation

The existing job installs `prettier@latest`. Prettier 3.9.4 changed formatting behavior and caused unrelated Dependabot PRs to fail even though they did not modify source files. Using `npm ci` and the repository-pinned formatter makes the check reproducible.

## Verification

- `npm ci`
- `npm exec -- prettier --check "lib/*.ts" "test/*.js" "examples/**/*.js"`
- `npm test` — 258 tests passed
- `git diff --check`