### PR TITLE
chore(ci): make lint checks non-mutating

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
   ],
   "scripts": {
     "//eslint": "performs static analysis over JS files and examples",
-    "eslint": "eslint --config eslint.config.mjs --fix test/*.js examples/**/*.js",
+    "eslint": "eslint --config eslint.config.mjs test/*.js examples/**/*.js",
+    "eslint:fix": "eslint --config eslint.config.mjs --fix test/*.js examples/**/*.js",
     "//tseslint": "performs static analysis over TS files and examples",
-    "tseslint": "eslint --config tseslint.config.mjs --fix lib/*.ts",
+    "tseslint": "eslint --config tseslint.config.mjs lib/*.ts",
+    "tseslint:fix": "eslint --config tseslint.config.mjs --fix lib/*.ts",
     "//prettier": "performs code formatting over project files and examples",
     "prettier": "prettier --write lib/*.ts test/*.js examples",
     "//prepare": "prepare project for distribution",

--- a/tseslint.config.mjs
+++ b/tseslint.config.mjs
@@ -62,6 +62,7 @@ export default tseslint.config(
             "@stylistic/no-extra-parens": ["off", 0],
             "@stylistic/space-before-function-paren": ["off", 0],
             "@stylistic/indent": ["off", 0],
+            "@stylistic/indent-binary-ops": ["off", 0],
             // Documentation format check
             "tsdoc/syntax": "warn"
         }


### PR DESCRIPTION
## Summary

- make `npm run eslint` and `npm run tseslint` check-only instead of silently modifying files in CI
- add explicit `eslint:fix` and `tseslint:fix` scripts for intentional local fixes
- disable `@stylistic/indent-binary-ops`, which conflicts with Prettier's formatting of TypeScript union types

## Motivation

After the development-tool refresh, `npm run tseslint` exited successfully while changing `lib/raygun.ts`; that ESLint-produced change then failed Prettier. CI did not catch the inconsistency because lint and formatting run in separate workspaces and the lint scripts used `--fix`.

Prettier remains the formatting authority, while ESLint now performs non-mutating static analysis in CI.

## Verification

- `npm ci`
- `npm run eslint` — passed without changing tracked files
- `npm run tseslint` — passed without changing tracked files
- `npm run eslint:fix` — passed
- `npm run tseslint:fix` — passed without conflicting with Prettier
- repository Prettier check
- `npm test` — 258 tests passed
- `npm run test:cjs`
- `npm audit` — 0 vulnerabilities
- `git diff --check`