### PR TITLE
chore: Release 2.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.2.8
+
+- Maintenance-only release; no public API or runtime behavior changes.
+- chore(deps): bump actions/setup-node from 6 to 7 (#528) (2026-08-04)
+- chore(deps-dev): bump tap from 21.7.2 to 21.7.5 (#529) (2026-08-04)
+- chore(deps-dev): bump eslint from 10.7.0 to 10.8.0 (#531) (2026-08-04)
+- chore(deps-dev): bump @types/node from 25.9.5 to 26.1.2 (#532) (2026-08-04)
+- chore(deps-dev): bump fast-uri from 3.1.2 to 3.1.4 (#527) (2026-08-01)
+- chore(deps-dev): bump fast-uri from 3.1.4 to 3.1.5 (#534) (2026-08-04)
+- chore(deps-dev): bump body-parser to 2.3.0 (#537) (2026-08-04)
+
 ## 2.2.7
 
 - chore(deps-dev): bump qs from 6.15.0 to 6.15.2 (#502) (2026-05-24)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raygun",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raygun",
-      "version": "2.2.7",
+      "version": "2.2.8",
       "dependencies": {
         "@types/express": "^5.0.0",
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raygun",
   "description": "Raygun package for Node.js, written in TypeScript",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "homepage": "https://github.com/MindscapeHQ/raygun4node",
   "author": {
     "name": "Raygun",


### PR DESCRIPTION
## Summary

- bump `raygun` from 2.2.7 to 2.2.8
- document the CI, test, lint, type-definition, and development lockfile maintenance included since 2.2.7
- clarify that this maintenance release does not change the public API or runtime behavior

## Release classification

Patch release. The included updates affect development tooling, CI, type definitions, and development dependency lockfiles only.

## Validation

- `npm test` (258 passing)
- `npm run test:cjs`
- `npm run eslint`
- `npm run tseslint`
- Prettier check
- `npm audit` (0 vulnerabilities)
- `npm audit --omit=dev` (0 vulnerabilities)
- `npm publish --dry-run` (`raygun@2.2.8`, 28 files)

## Release workflow

After approval and green CI, publish `raygun@2.2.8` to npm before merging this PR, then create GitHub release `v2.2.8` from the merged release commit as documented in `RELEASING.md`.
