### PR TITLE
chore: temporarily pin Keyv and cache dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
     "debug": "^4.3.4",
     "stack-trace": "0.0.10"
   },
+  "overrides": {
+    "keyv": "4.5.4",
+    "flat-cache": "4.0.1",
+    "file-entry-cache": "8.0.0"
+  },
   "keywords": [
     "APM",
     "crash",


### PR DESCRIPTION
## Summary

Temporarily override the development-only cache dependency chain to the already-resolved known-clean versions:

- `keyv@4.5.4`
- `flat-cache@4.0.1`
- `file-entry-cache@8.0.0`

This is defense in depth during the active [Keyv/Cacheable npm supply-chain incident](https://socket.dev/supply-chain-attacks/keyv-and-cacheable-compromise). The known compromised releases are in newer major-version lines and no compromised package was found in the repository, lockfile, or installed tree.

The overrides apply to installs rooted in this repository; they do not impose resolutions on consumers of the published `raygun` package.

## Temporary control

This must be reviewed by **31 August 2026**. The removal criteria, current GitHub target date, rescanning checklist, and unroll procedure are tracked in #542.

## Dependency impact

`npm install --package-lock-only --ignore-scripts` produced no `package-lock.json` change because the pinned versions were already resolved. `npm ls` confirms all three overrides are active.

## Verification

- `npm ci`
- `npm test`
- `npm run test:cjs`
- `npm run eslint`
- `npm run tseslint`
- Prettier check
- `npm ls keyv flat-cache file-entry-cache --all`
- npm audit: 0 reported vulnerabilities

Refs #542